### PR TITLE
Feature/header

### DIFF
--- a/src/app/@modal/(.)sign-in/page.tsx
+++ b/src/app/@modal/(.)sign-in/page.tsx
@@ -1,33 +1,5 @@
-// import SignInPage from '@/pages/SignInPage';
-
-// export default function WrapperSignInPage() {
-//   return <SignInPage />;
-// }
-'use client';
-import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react';
-import { useRouter } from 'next/navigation';
-import SignInButton from '../../../features/sign-in/components/SignInButton';
+import SignInModal from '@/features/sign-in/components/SignInModal';
 
 export default function WrapperSignInPage() {
-  const router = useRouter();
-
-  return (
-    <>
-      <Modal isOpen={true} backdrop="blur" onOpenChange={() => router.back()}>
-        <ModalContent>
-          <>
-            <ModalHeader className="flex flex-col gap-1 text-center">로그인</ModalHeader>
-            <ModalBody>
-              <SignInButton provider="google" />
-
-              <SignInButton provider="naver" />
-
-              <SignInButton provider="kakao" />
-            </ModalBody>
-            <ModalFooter />
-          </>
-        </ModalContent>
-      </Modal>
-    </>
-  );
+  return <SignInModal />;
 }

--- a/src/app/@modal/(.)sign-in/page.tsx
+++ b/src/app/@modal/(.)sign-in/page.tsx
@@ -1,0 +1,33 @@
+// import SignInPage from '@/pages/SignInPage';
+
+// export default function WrapperSignInPage() {
+//   return <SignInPage />;
+// }
+'use client';
+import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react';
+import { useRouter } from 'next/navigation';
+import SignInButton from '../../../features/sign-in/components/SignInButton';
+
+export default function WrapperSignInPage() {
+  const router = useRouter();
+
+  return (
+    <>
+      <Modal isOpen={true} backdrop="blur" onOpenChange={() => router.back()}>
+        <ModalContent>
+          <>
+            <ModalHeader className="flex flex-col gap-1 text-center">로그인</ModalHeader>
+            <ModalBody>
+              <SignInButton provider="google" />
+
+              <SignInButton provider="naver" />
+
+              <SignInButton provider="kakao" />
+            </ModalBody>
+            <ModalFooter />
+          </>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/@modal/page.tsx
+++ b/src/app/@modal/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,15 +22,18 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="">
+    <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <Providers>
           <Header />
           {children}
+          {modal}
         </Providers>
       </body>
     </html>

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,5 +1,9 @@
-import SignInPage from '@/pages/SignInPage';
+import SignInModal from '@/features/sign-in/components/SignInModal';
 
 export default function WrapperSignInPage() {
-  return <SignInPage />;
+  return (
+    <div className="bg-background h-screen">
+      <SignInModal />
+    </div>
+  );
 }

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
   }, []);
 
   return (
-    <div className={`sticky top-0 z-[100] transition-all duration-300`}>
+    <div className={`${hasScrolled ? 'z-[100]' : ''} sticky top-0 transition-all duration-300`}>
       <Navbar
         className={`${hasScrolled ? 'mx-auto h-20 max-w-full bg-[#fff3f6]/40 px-6' : 'mx-auto h-[90px] bg-transparent px-30 pt-3 !backdrop-filter-none'} transition-all duration-300 ease-in-out`}
         isMenuOpen={isMenuOpen}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { Button, Input, Link, Navbar, NavbarBrand, NavbarContent, NavbarItem, NavbarMenuToggle } from '@heroui/react';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 export default function Header() {
   const [hasScrolled, setHasScrolled] = React.useState(false);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+
+  const router = useRouter();
   React.useEffect(() => {
     const handleScroll = () => {
       setHasScrolled(window.scrollY > 10);
@@ -49,7 +52,7 @@ export default function Header() {
         <div className="flex-1">
           <NavbarContent justify="end">
             <NavbarItem>
-              <Button as={Link} color="primary" href="#" variant="flat">
+              <Button color="primary" onPress={() => router.push('/sign-in')} variant="flat">
                 로그인
               </Button>
             </NavbarItem>

--- a/src/features/sign-in/components/SignInModal.tsx
+++ b/src/features/sign-in/components/SignInModal.tsx
@@ -1,0 +1,26 @@
+'use client';
+import SignInButton from '@/features/sign-in/components/SignInButton';
+import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react';
+import { useRouter } from 'next/navigation';
+
+export default function SignInModal() {
+  const router = useRouter();
+
+  return (
+    <Modal defaultOpen backdrop="opaque" onOpenChange={() => router.back()}>
+      <ModalContent>
+        <>
+          <ModalHeader className="flex flex-col gap-1 text-center">로그인</ModalHeader>
+          <ModalBody>
+            <SignInButton provider="google" />
+
+            <SignInButton provider="naver" />
+
+            <SignInButton provider="kakao" />
+          </ModalBody>
+          <ModalFooter />
+        </>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## ✨ 작업 개요

- HeaderComponent 및 Signin Modal 작업
## 📌 변경사항 요약

SignIn Page -> SignIn Modal로 변경

## 🔍 상세 설명
- SingIn Page를 Modal로 변경 (Hero UI - Modal 사용)
- /sign-in 경로에 대하여 Parallel Routes 및 Intercepting Routes 적용, Modal 띄워줌
- SignInModal은 src > features > sign-in > components 안에 생성
- app의 WrapperSignInPage()는  모두 SignInModal 컴포넌트 렌더링

## 📝 참고사항

- Storybook 해야함
- 기존 pages > SignInPage 삭제 여부 결정