### PR TITLE
feat(auth-store): auth provider 완성

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,9 @@
 'use client';
 
-import { Button } from '@/components/common/Button';
+import { Button } from '@/components/common/button';
 import { Input } from '@/components/common/input';
-import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
 
 export default function Page() {
-  const { data: session } = useSession();
-
-  useEffect(() => {
-    console.log(session);
-  }, [session]);
-
   return (
     <>
       <div className="relative z-10 flex h-screen items-center justify-center gap-10">

--- a/src/features/add-info/components/AddInfoForm.tsx
+++ b/src/features/add-info/components/AddInfoForm.tsx
@@ -11,6 +11,8 @@ import { useEffect, useState } from 'react';
 
 export default function AddInfoForm() {
   const { data: session, status } = useSession();
+  // TODO: useSession대신 로그인 정보로 바꿔야함
+  // const user = useAuthStore((state) => state.user);
   const [interests, setInterests] = useState<string[]>([]);
   const [name, setName] = useState<string>('');
   const [email, setEmail] = useState<string>('');

--- a/src/providers/AuthSyncProvider.tsx
+++ b/src/providers/AuthSyncProvider.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useAuthStore } from '@/store/auth/useAuthStore';
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+import { User } from '../types/user';
+
+export function AuthSyncProvider({ children }: { children: React.ReactNode }) {
+  const { data: session } = useSession();
+  const setUser = useAuthStore((state) => state.setUser);
+
+  useEffect(() => {
+    if (session?.user) {
+      setUser(session.user as User);
+    }
+  }, [session, setUser]);
+
+  return <>{children}</>;
+}

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -2,11 +2,14 @@
 
 import { HeroUIProvider } from '@heroui/react';
 import { SessionProvider } from 'next-auth/react';
+import { AuthSyncProvider } from './AuthSyncProvider';
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <HeroUIProvider>
-      <SessionProvider>{children}</SessionProvider>
+      <SessionProvider>
+        <AuthSyncProvider>{children}</AuthSyncProvider>
+      </SessionProvider>
     </HeroUIProvider>
   );
 }

--- a/src/store/auth/useAuthStore.ts
+++ b/src/store/auth/useAuthStore.ts
@@ -1,0 +1,22 @@
+import type { User } from '@/types/user';
+import { create } from 'zustand';
+
+interface AuthState {
+  user: User | null;
+  isLoading: boolean;
+  error: string | null;
+  setUser: (user: User) => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  isLoading: false,
+  error: null,
+  setUser: (user: User) => {
+    set({ user });
+  },
+  logout: () => {
+    set({ user: null, error: null });
+  },
+}));

--- a/src/stories/common/Button.stories.tsx
+++ b/src/stories/common/Button.stories.tsx
@@ -1,5 +1,5 @@
+import { Button } from '@/components/common/button';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { Button } from '../../components/common/Button';
 
 const meta: Meta<typeof Button> = {
   title: 'Common/Button',

--- a/src/stories/common/Input.stories.tsx
+++ b/src/stories/common/Input.stories.tsx
@@ -1,7 +1,7 @@
+import { Input } from '@/components/common/input';
+import { LABELS } from '@/components/common/input/labels';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { useState } from 'react';
-import { Input } from '../../components/common/input';
-import { LABELS } from '../../components/common/input/labels';
 
 const meta: Meta<typeof Input> = {
   title: 'Common/Input',

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,3 +1,6 @@
+import { type User as DbUser } from '@/db/schema/users';
+
+export type User = Pick<DbUser, 'id' | 'email' | 'image' | 'phone'>;
 export interface UpdateUserDto {
   name?: string;
   email?: string;


### PR DESCRIPTION
## ✨ 작업 개요
1. 로그인 후 유저 정보를 Provider 패턴을 통해 클라이언트 측 store에서 관리 

```js
user {
  email 
  id 
  name
  image // image url 
}
```

2. components/common/Button -> components/common/button
으로 기존 대문자 -> 소문자로 컨벤션 통일 

3. storybook import 수정 
기존 import 방식 
`../../components/~`
수정 후 import 방식
`@/components/~`

## 🔍 상세 설명
user가 로그인을 진행할 경우 
AuthSyncProvider에서 auth.js의 useSession을 활용 (아래 슈도코드처럼 동작)
```
useEffect(
if (유저 존재?) {
    setuser(유저)
  }
)
```
다른 페이지에서 활용할 때는 이제 useAuthStore에서 user정보를 조회하면 됨 

## 📝 참고사항
따로 없습니다