### PR TITLE
Feature/profile

### DIFF
--- a/src/_pages/MainPage.tsx
+++ b/src/_pages/MainPage.tsx
@@ -1,3 +1,4 @@
+'use client';
 import CurrentPopupList from '@/features/main/components/CurrentPopupList';
 import MainBanner from '@/features/main/components/MainBanner';
 import UpcomingPopupList from '@/features/main/components/UpcomingPopupList';

--- a/src/_pages/ProfilePage.tsx
+++ b/src/_pages/ProfilePage.tsx
@@ -4,12 +4,16 @@ import HeroSection from '@/components/common/hero-section';
 import { useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { useLocalStorage } from 'react-haiku';
 import Button from '../components/common/button';
+import CardComponent from '../components/common/card';
 import { clientApi } from '../libs/api';
+import { upcomingPopupList } from '../mock/mockdata';
 
 export default function ProfilePage() {
   const { data: session, status } = useSession();
   const [userInfo, setUserInfo] = useState<any>(null);
+  const [favorites] = useLocalStorage<number[]>('favoritePopups', []);
 
   const getUserInfo = async () => {
     try {
@@ -55,7 +59,30 @@ export default function ProfilePage() {
           <Button>프로필 수정</Button>
         </div>
       </section>
-      <section id="defaultSt" className="mx-auto mt-8 grid max-w-5xl grid-cols-3 gap-6"></section>
+
+      {/* 관심팝업 */}
+      {/* TODO: 페이지네이션 어떻게 할지 추가적인 설정 필요 */}
+      <section className="mx-auto mt-12 mb-10 max-w-5xl pb-10">
+        <h2 className="mb-4 text-2xl font-bold">나의 관심 팝업</h2>
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
+          {upcomingPopupList
+            .filter((p) => favorites.includes(p.id))
+            .map((p) => (
+              <CardComponent
+                key={p.id}
+                id={p.id}
+                title={p.title}
+                thumbnail={p.thumbnail}
+                tags={p.tags}
+                eventStart={p.event_start}
+                eventEnd={p.event_end}
+                variant="compact"
+                isFavorite={true}
+              />
+            ))}
+        </div>
+        {favorites.length === 0 && <p className="col-span-3 text-center text-gray-500">아직 관심 팝업이 없습니다.</p>}
+      </section>
     </main>
   );
 }

--- a/src/_pages/ProfilePage.tsx
+++ b/src/_pages/ProfilePage.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import HeroSection from '@/components/common/hero-section';
-import { useSession } from 'next-auth/react';
+import { Divider } from '@heroui/react';
+import { signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -14,7 +15,7 @@ import { upcomingPopupList } from '../mock/mockdata';
 export default function ProfilePage() {
   const { data: session, status } = useSession();
   const [userInfo, setUserInfo] = useState<any>(null);
-  const [favorites] = useLocalStorage<number[]>('favoritePopups', []);
+  const [favorites, setFavorites] = useLocalStorage<number[]>('favoritePopups', []);
   const router = useRouter();
   const getUserInfo = async () => {
     try {
@@ -28,6 +29,23 @@ export default function ProfilePage() {
     }
   };
 
+  // TODO: 알림 -> 토스트로 변경
+  const deleteUser = async () => {
+    if (!confirm('정말 탈퇴하시겠습니까?')) return;
+
+    try {
+      if (status === 'authenticated' && session?.user?.id) {
+        await clientApi(`/api/users/${session.user.id}`, { method: 'DELETE' });
+        alert('회원 탈퇴가 완료되었습니다.');
+        // 세션 종료 및 홈으로 리다이렉트
+        await signOut({ callbackUrl: '/' });
+      }
+    } catch (error) {
+      console.error('Failed to delete user:', error);
+      alert('탈퇴 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
+  };
+
   useEffect(() => {
     getUserInfo();
   }, [session, status]);
@@ -36,9 +54,8 @@ export default function ProfilePage() {
     <main className="min-h-screen">
       <HeroSection
         title={`${userInfo && userInfo[0]?.name}님 환영합니다!`}
-        description="프로필과 관심 팝업을 볼 수 있습니다."
+        description="프로필 수정과 관심 팝업은 여기에서 볼 수 있어요"
       />
-
       {/* 프로필 */}
       <section id="defaultSt" className="mx-auto mt-8 flex max-w-5xl items-center justify-between border-b pb-8">
         <div className="flex items-center gap-6">
@@ -59,14 +76,29 @@ export default function ProfilePage() {
         {/* 프로필수정 */}
         <div className="flex gap-3">
           <Button onPress={() => router.push('/add-info')}>프로필 수정</Button>
+          <Button onPress={() => signOut()}>로그아웃</Button>
         </div>
       </section>
-
       {/* 관심팝업 */}
       {/* TODO: 페이지네이션 어떻게 할지 추가적인 설정 필요 */}
-      <section className="mx-auto mt-12 mb-10 max-w-5xl pb-10">
+      <section className="mx-auto mt-12 max-w-5xl">
         <h2 className="mb-4 text-2xl font-bold">나의 관심 팝업</h2>
-        <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
+        {/* 관심 팝업 전체 삭제 버튼 : 관심팝업이 1개 이상일 경우*/}
+        {favorites.length > 0 && (
+          <div className="mb-4 text-right">
+            <Button
+              size="sm"
+              onPress={() => {
+                if (confirm('관심 팝업을 전부 삭제하시겠습니까?')) {
+                  setFavorites([]);
+                }
+              }}
+            >
+              전체 삭제
+            </Button>
+          </div>
+        )}
+        <div className="grid grid-cols-1 gap-16 md:grid-cols-2">
           {upcomingPopupList
             .filter((p) => favorites.includes(p.id))
             .map((p) => (
@@ -84,6 +116,13 @@ export default function ProfilePage() {
             ))}
         </div>
         {favorites.length === 0 && <p className="col-span-3 text-center text-gray-500">아직 관심 팝업이 없습니다.</p>}
+      </section>
+      {/* 회원탈퇴 */}
+      <section className="mx-auto mt-12 mb-10 max-w-5xl pb-10">
+        <Divider className="my-4" />
+        <p onClick={deleteUser} className="cursor-pointer text-end text-gray-500 hover:underline">
+          회원을 탈퇴하고 싶으신가요?
+        </p>
       </section>
     </main>
   );

--- a/src/_pages/ProfilePage.tsx
+++ b/src/_pages/ProfilePage.tsx
@@ -1,8 +1,61 @@
+'use client';
+
+import HeroSection from '@/components/common/hero-section';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import Button from '../components/common/button';
+import { clientApi } from '../libs/api';
+
 export default function ProfilePage() {
+  const { data: session, status } = useSession();
+  const [userInfo, setUserInfo] = useState<any>(null);
+
+  const getUserInfo = async () => {
+    try {
+      if (status === 'authenticated' && session?.user?.id) {
+        const res = await clientApi(`/api/users/${session?.user?.id}`, { method: 'GET' });
+        console.log(res);
+        setUserInfo(res);
+      }
+    } catch (error) {
+      console.error('Failed to get user info', error);
+    }
+  };
+
+  useEffect(() => {
+    getUserInfo();
+  }, [session, status]);
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold">Profile Page</h1>
-      <p>프로필 페이지 내용이 여기에 들어갑니다.</p>
-    </div>
+    <main className="min-h-screen">
+      <HeroSection
+        title={`${userInfo && userInfo[0]?.name}님 환영합니다!`}
+        description="프로필과 관심 팝업을 볼 수 있습니다."
+      />
+
+      {/* 프로필 */}
+      <section id="defaultSt" className="mx-auto mt-8 flex max-w-5xl items-center justify-between border-b pb-8">
+        <div className="flex items-center gap-6">
+          {userInfo && userInfo[0]?.image && (
+            <Image src={userInfo[0]?.image} alt="profile" width={80} height={80} className="rounded-full" />
+          )}
+          <div className="flex-col items-start">
+            <div className="flex items-center gap-2">
+              <span className="text-xl font-bold">{userInfo && userInfo[0]?.name}</span>
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+              <span className="rounded px-2 py-1 font-mono text-xs">{userInfo && userInfo[0]?.email}</span>
+              <span className="rounded px-2 py-1 font-mono text-xs">{userInfo && userInfo[0]?.phone}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <Button>프로필 수정</Button>
+        </div>
+      </section>
+      <section id="defaultSt" className="mx-auto mt-8 grid max-w-5xl grid-cols-3 gap-6"></section>
+    </main>
   );
 }

--- a/src/_pages/ProfilePage.tsx
+++ b/src/_pages/ProfilePage.tsx
@@ -3,6 +3,7 @@
 import HeroSection from '@/components/common/hero-section';
 import { useSession } from 'next-auth/react';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useLocalStorage } from 'react-haiku';
 import Button from '../components/common/button';
@@ -14,7 +15,7 @@ export default function ProfilePage() {
   const { data: session, status } = useSession();
   const [userInfo, setUserInfo] = useState<any>(null);
   const [favorites] = useLocalStorage<number[]>('favoritePopups', []);
-
+  const router = useRouter();
   const getUserInfo = async () => {
     try {
       if (status === 'authenticated' && session?.user?.id) {
@@ -55,8 +56,9 @@ export default function ProfilePage() {
           </div>
         </div>
 
+        {/* 프로필수정 */}
         <div className="flex gap-3">
-          <Button>프로필 수정</Button>
+          <Button onPress={() => router.push('/add-info')}>프로필 수정</Button>
         </div>
       </section>
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,5 @@
+import ProfilePage from '@/_pages/ProfilePage';
+
+export default function WrapperProfilePage() {
+  return <ProfilePage />;
+}

--- a/src/components/common/card/index.tsx
+++ b/src/components/common/card/index.tsx
@@ -1,24 +1,62 @@
 import Chip from '@/components/common/chip';
 import { formatDate } from '@/utils/dateformatter';
-import { Card, CardBody, CardFooter, Image } from '@heroui/react';
+import { HeartIcon as HeartIconOutline } from '@heroicons/react/24/outline';
+import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid';
+import { Button, Card, CardBody, CardFooter, CardHeader, Image } from '@heroui/react';
 import NextImage, { StaticImageData } from 'next/image';
+import { useRouter } from 'next/navigation';
 import { If } from 'react-haiku';
 
 interface CardProps {
+  id: number;
   title?: string;
   thumbnail: string | StaticImageData;
   tags?: string[];
   eventStart?: string;
   eventEnd?: string;
   variant?: 'default' | 'compact';
+  isFavorite?: boolean;
+  onToggleFav?: (id: number) => void;
 }
 
-export default function CardComponent({ title, thumbnail, tags, eventStart, eventEnd, variant }: CardProps) {
+export default function CardComponent({
+  id,
+  title,
+  thumbnail,
+  tags,
+  eventStart,
+  eventEnd,
+  variant = 'default',
+  isFavorite,
+  onToggleFav,
+}: CardProps) {
   const isCompact = variant === 'compact';
+
+  const handleFavClick = () => {
+    if (onToggleFav) {
+      onToggleFav(id);
+    }
+  };
+
+  const router = useRouter();
   return (
     <>
       <If isTrue={!isCompact}>
-        <Card className="flex max-w-[240px] cursor-pointer flex-col overflow-hidden shadow-sm" radius="sm">
+        <Card
+          isPressable
+          className="relative flex max-w-[240px] cursor-pointer flex-col overflow-hidden shadow-sm"
+          radius="sm"
+          onPress={() => router.push(`/event/${id}`)}
+        >
+          <CardHeader className="absolute top-1 z-10 flex-col items-end">
+            <Button isIconOnly variant="light" radius="full" onPress={handleFavClick}>
+              {isFavorite ? (
+                <HeartIconSolid className="h-6 w-6 text-red-500" />
+              ) : (
+                <HeartIconOutline className="h-6 w-6 text-[#ffc0d4]" />
+              )}
+            </Button>
+          </CardHeader>
           <CardBody className="overflow-x-auto p-0">
             <Image
               isZoomed
@@ -32,13 +70,12 @@ export default function CardComponent({ title, thumbnail, tags, eventStart, even
               loading="eager"
             />
           </CardBody>
-
           <CardFooter className="absolute bottom-0 z-10 flex-col items-start bg-gradient-to-t from-black/60 via-black/20 to-transparent">
             <h4 className="mb-1 font-bold text-white">{title}</h4>
             <small className="text-default-400">
               {formatDate(eventStart ?? '')} ~ {formatDate(eventEnd ?? '')}
             </small>
-            <div className="flex gap-1">{tags && tags.map((tag, index) => <Chip key={index}>{tag}</Chip>)}</div>
+            <div className="flex gap-1">{tags && tags.map((tag, idx) => <Chip key={idx}>{tag}</Chip>)}</div>
           </CardFooter>
         </Card>
       </If>
@@ -47,9 +84,9 @@ export default function CardComponent({ title, thumbnail, tags, eventStart, even
           className="bg-bgcolor max-w-[480px] rounded-3xl border border-white/20 bg-white/10 p-10 py-4 shadow-2xl backdrop-blur-2xl"
           shadow="none"
           radius="sm"
+          onPress={() => router.push(`/event/${id}`)}
         >
           <CardBody className="relative grid grid-cols-6 gap-6 px-0 md:grid-cols-12 md:gap-4">
-            {/* 이미지 영역 */}
             <div className="relative col-span-6 md:col-span-4">
               <Image
                 alt="썸네일"
@@ -59,19 +96,15 @@ export default function CardComponent({ title, thumbnail, tags, eventStart, even
                 width={140}
               />
             </div>
-
-            {/* 우측 텍스트 영역 */}
             <div className="relative col-span-6 flex cursor-pointer flex-col justify-end gap-2 md:col-span-8">
-              {/* 좋아요 아이콘 - 우측 상단 고정 */}
-              <div className="text-default-400 absolute top-0 right-0 p-2 text-sm">❤️ 123</div>
+              {/* 좋아요/조회수 아이콘 (compact) */}
+              <div className="text-default-400 absolute top-0 right-0 p-2 text-sm">❤️ {isFavorite ? '♥' : '123'}</div>
               <div className="text-default-400 absolute top-0 right-15 p-2 text-sm">👁️ 123</div>
-
-              {/* 나머지 정보 - 좌측 하단 정렬 */}
               <div className="flex flex-col gap-1">
                 <h4 className="text-foreground text-base font-bold">{title}</h4>
-                <p className="text-default-500 text-sm">📍 홍대입구역</p>
+                <p className="text-default-500 text-sm">📍 홍대구역</p>
                 <p className="text-default-400 text-sm">
-                  {eventStart && ` ~ ${formatDate(eventStart)}`}~ {eventEnd && ` ~ ${formatDate(eventEnd)}`}
+                  {eventStart && `~ ${formatDate(eventStart)}`} {eventEnd && `~ ${formatDate(eventEnd)}`}
                 </p>
               </div>
             </div>

--- a/src/components/common/card/index.tsx
+++ b/src/components/common/card/index.tsx
@@ -98,7 +98,7 @@ export default function CardComponent({
             </div>
             <div className="relative col-span-6 flex cursor-pointer flex-col justify-end gap-2 md:col-span-8">
               {/* 좋아요/조회수 아이콘 (compact) */}
-              <div className="text-default-400 absolute top-0 right-0 p-2 text-sm">❤️ {isFavorite ? '♥' : '123'}</div>
+              <div className="text-default-400 absolute top-0 right-0 p-2 text-sm">❤️ {isFavorite ? '' : '123'}</div>
               <div className="text-default-400 absolute top-0 right-15 p-2 text-sm">👁️ 123</div>
               <div className="flex flex-col gap-1">
                 <h4 className="text-foreground text-base font-bold">{title}</h4>

--- a/src/components/layouts/header/index.tsx
+++ b/src/components/layouts/header/index.tsx
@@ -15,6 +15,7 @@ import {
   NavbarMenuToggle,
 } from '@heroui/react';
 import { signOut, useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { If, useScrollPosition } from 'react-haiku';
 import SignInModal from '../../../features/sign-in/components/SignInModal';
@@ -25,6 +26,7 @@ export default function Header() {
   const [scroll, _] = useScrollPosition() as [{ x: number; y: number }, unknown];
 
   const { data: session } = useSession();
+  const router = useRouter();
 
   useEffect(() => {
     if (!hasScrolled && scroll.y > 70) setHasScrolled(true);
@@ -85,7 +87,9 @@ export default function Header() {
                     />
                   </DropdownTrigger>
                   <DropdownMenu aria-label="Profile Actions" variant="light" color="danger">
-                    <DropdownItem key="profile">프로필페이지</DropdownItem>
+                    <DropdownItem key="profile" onPress={() => router.push('/profile')}>
+                      프로필페이지
+                    </DropdownItem>
                     <DropdownItem key="logout" variant="flat" color="danger" onPress={() => signOut()}>
                       로그아웃
                     </DropdownItem>

--- a/src/features/events/components/EventList.tsx
+++ b/src/features/events/components/EventList.tsx
@@ -19,13 +19,13 @@ export default function EventList({ events }: Props) {
         <li key={evt.id} className="transform transition-transform hover:scale-105">
           <Link href={`/event/${evt.id}`} className="block">
             <CardComponent
+              id={evt.id}
               title={evt.title}
               thumbnail={evt.thumbnail}
               tags={evt.tags ?? []}
               eventStart={evt.eventStart}
               eventEnd={evt.eventEnd}
             />
-
           </Link>
         </li>
       ))}

--- a/src/features/main/components/CurrentPopupList.tsx
+++ b/src/features/main/components/CurrentPopupList.tsx
@@ -1,11 +1,28 @@
 'use client';
 
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useLocalStorage } from 'react-haiku';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import CardComponent from '../../../components/common/card';
 import { upcomingPopupList } from '../../../mock/mockdata';
 
 export default function CurrentPopupList() {
+  const [favorites, setFavorites] = useLocalStorage<number[]>('favoritePopups', []);
+  // NOTE: next.js가 기본적으로 컴포넌트를 서버에서 미리 렌더링(SSR/SSG)하기 때문에 localStorage에 바로 접근할 수 없음
+  // 개발환경에서는 느린데 빌드 후에는 어떨지 모르겠음.
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) {
+    // TODO: Skelleton
+    return null;
+  }
+  const handleFavToggle = (id: number) => {
+    setFavorites((prev: number[]) => (prev.includes(id) ? prev.filter((fav) => fav !== id) : [...prev, id]));
+  };
   return (
     <section className="mx-auto mb-10 max-w-6xl overflow-hidden px-4">
       <h2 className="mb-4 text-2xl font-bold">지금! 서울 인기 팝업</h2>
@@ -34,15 +51,17 @@ export default function CurrentPopupList() {
       >
         {upcomingPopupList.map((popup) => (
           <SwiperSlide key={popup.id} className="min-w-0">
-            <Link href={`/event/${popup.id}`} className="block">
-              <CardComponent
-                title={popup.title}
-                thumbnail={popup.thumbnail}
-                tags={popup.tags}
-                eventStart={popup.event_start}
-                eventEnd={popup.event_end}
-              />
-            </Link>
+            <CardComponent
+              id={popup.id}
+              title={popup.title}
+              thumbnail={popup.thumbnail}
+              tags={popup.tags}
+              eventStart={popup.event_start}
+              eventEnd={popup.event_end}
+              isFavorite={favorites.includes(popup.id)}
+              onToggleFav={handleFavToggle}
+            />
+            {/* </Link> */}
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/features/main/components/UpcomingPopupList.tsx
+++ b/src/features/main/components/UpcomingPopupList.tsx
@@ -22,6 +22,7 @@ export default function UpcomingPopupList() {
           <Link href={`/event/${popup.id}`} key={popup.id} className="block">
             <CardComponent
               key={popup.id}
+              id={popup.id}
               title={popup.title}
               thumbnail={popup.thumbnail}
               tags={popup.tags}


### PR DESCRIPTION
## ✨ 작업 개요

프로필페이지 작업
## 📌 변경사항 요약

1. 최상단에 useClient추가 : 리팩토링과정에서 제거 가능하면 제거할 예정
2. _pages : 프로필페이지 추가
3. app 내에 프로필페이지(wrapper) 추가
4. 카드컴포넌트에 관심팝업 토글에 따른 하트 아이콘 추가
5. 헤더 드롭다운 메뉴에 프로필페이지 연결
6. 카드 컴포넌트 props 변경에 따른 수정(EventList.tsx)
7. 메인페이지 > 현재 운영 팝업 섹션 > 카드 컴포넌트 : 관심팝업 등록/제거  -> localStorage 이용
8. 6. 카드 컴포넌트 props 변경에 따른 수정(UpcomingPopupList.tsx)

## 🔍 상세 설명

1. react-haiku의 useLocalStorage() 활용했습니다.
2. 프로필페이지 섹션 구성
    - 유저 정보 / 프로필 수정 버튼(/add-info로 연결) / 로그아웃 버튼
    - 나의 관심 팝업 리스트
    - 회원탈퇴 

## 📝 참고사항

관심 팝업을 로컬 스토리지보다 서버에 저장하는 게 더 좋을 것 같습니다.
next.js가 기본적으로 컴포넌트를 서버에서 미리 렌더링(SSR/SSG)하기 때문에 localStorage에 바로 접근할 수 없기도 하고,
서버에 저장하는 게 활용 범위가 더 넓을 것 같습니다.