### PR TITLE
Refactor/event register 1차 컴포넌트 및 훅 분리 작업

### DIFF
--- a/src/_pages/EventRegisterPage.tsx
+++ b/src/_pages/EventRegisterPage.tsx
@@ -1,228 +1,74 @@
 'use client';
 
 import Button from '@/components/common/button';
-import Chip from '@/components/common/chip';
 import Input from '@/components/common/input';
-import { FolderPlusIcon, MapPinIcon } from '@heroicons/react/24/outline';
-import type { DateValue } from '@heroui/react';
-import { Calendar, Checkbox, CheckboxGroup, Popover, PopoverContent, PopoverTrigger, Textarea } from '@heroui/react';
+import { LABELS } from '@/components/common/input/labels';
+import EventDatePicker from '@/features/event/register/components/EventDatePicker';
+import EventExtraInfo from '@/features/event/register/components/EventExtraInfo';
+import EventImageUpload from '@/features/event/register/components/EventImageUpload';
+import EventLocation from '@/features/event/register/components/EventLocation';
+import EventRecruitment from '@/features/event/register/components/EventRecruitment';
+import { otherInfoOptions } from '@/features/event/register/constants';
+import useEventRegisterForm from '@/features/event/register/hooks/useEventRegisterForm';
+import { Textarea } from '@heroui/react';
 import { useSession } from 'next-auth/react';
-import Image from 'next/image';
 import Script from 'next/script';
-import { useCallback, useEffect, useState } from 'react';
-import { useDropzone } from 'react-dropzone';
-import { LABELS } from '../components/common/input/labels';
-import { clientApi } from '../libs/api';
-import { uploadImageToStorage, type UploadedImage } from '../utils/imageUpload';
 
+// TODO: 폼 제출이 완료된 다음에 알림 + 페이지이동(호스트센터 / 상세페이지)
 declare global {
   interface Window {
     daum: any;
   }
 }
 
-// 기타 안내 사항 데이터
-const otherInfoOptions = [
-  { id: 'parking_available', label: '주차가능' },
-  { id: 'no_parking', label: '주차불가' },
-  { id: 'kids_zone', label: '웰컴 키즈존' },
-  { id: 'no_kids_zone', label: '노키즈존' },
-  { id: 'free_admission', label: '입장료 무료' },
-  { id: 'paid_admission', label: '입장료 유료' },
-  { id: 'pets_allowed', label: '반려동물 동반가능' },
-  { id: 'no_pets_allowed', label: '반려동물 입장금지' },
-  { id: 'wifi', label: '와이파이 가능' },
-  { id: 'photography_allowed', label: '사진촬영 가능' },
-];
-
-interface FileWithPreview extends File {
-  preview: string;
-}
-
 export default function EventRegisterPage() {
   const { data: session } = useSession();
   const hostId = session?.user?.id;
 
-  // 제목
-  const [title, setTitle] = useState('');
-  // 본문
-  const [description, setDescription] = useState('');
-  // 이메일
-  const [email, setEmail] = useState('');
-  // 모집 방법
-  const [recruitmentMethod, setRecruitmentMethod] = useState<string[]>([]);
-  // 참가자 수
-  const [capacity, setCapacity] = useState<number>(0);
-  // 안내사항 선택 상태
-  const [selectedInfo, setSelectedInfo] = useState<string[]>([]);
-  // 썸네일 - 로컬 미리보기용
-  const [thumbnail, setThumbnail] = useState<FileWithPreview[]>([]);
-  // 업로드된 이미지 정보
-  const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null);
-  // 업로드 상태
-  const [isUploading, setIsUploading] = useState(false);
-  // 날짜 상태
-  const [eventStart, setEventStart] = useState<DateValue | null>(null);
-  const [eventEnd, setEventEnd] = useState<DateValue | null>(null);
-  // 주소 상태
-  const [zonecode, setZonecode] = useState(''); // 우편번호
-  const [address, setAddress] = useState(''); // 주소
-  const [extraAddress, setExtraAddress] = useState(''); // 상세 주소
+  // HACK: 폼에서 관리하는 상태가 많으니까 useReducer로 통합하는 건 어떨까
+  const { fields, imageUpload, handlers } = useEventRegisterForm(hostId);
+  const {
+    title,
+    setTitle,
+    description,
+    setDescription,
+    email,
+    setEmail,
+    recruitmentMethod,
+    setRecruitmentMethod,
+    capacity,
+    setCapacity,
+    selectedInfo,
+    eventStart,
+    setEventStart,
+    eventEnd,
+    setEventEnd,
+    zonecode,
+    address,
+    extraAddress,
+    setExtraAddress,
+  } = fields;
 
-  console.log(eventStart);
-  console.log(thumbnail);
-  console.log('Uploaded image:', uploadedImage);
-
-  const handleOpenPostcode = () => {
-    if (typeof window.daum === 'undefined' || typeof window.daum.Postcode === 'undefined') {
-      alert('Daum Postcode 서비스가 로드되지 않았습니다.');
-      return;
-    }
-
-    new window.daum.Postcode({
-      oncomplete: function (data: any) {
-        let fullAddress = data.address;
-        console.log(data);
-        let extraAddress = '';
-
-        if (data.addressType === 'R') {
-          if (data.bname !== '') {
-            extraAddress += data.bname;
-          }
-          if (data.buildingName !== '') {
-            extraAddress += extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
-          }
-          fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
-        }
-
-        // NOTE: 디버깅할 때 쓸 것, 선택된 주소를 alert으로 표시
-        // alert(`우편번호: ${data.zonecode}\n주소: ${fullAddress}`);
-
-        setAddress(fullAddress);
-        setZonecode(data.zonecode);
-        setExtraAddress(extraAddress);
-      },
-    }).open();
-  };
-
-  const onDrop = useCallback(async (acceptedFiles: File[]) => {
-    if (acceptedFiles.length === 0) return;
-
-    const file = acceptedFiles[0];
-
-    // 로컬 미리보기 설정
-    setThumbnail([
-      Object.assign(file, {
-        preview: URL.createObjectURL(file),
-      }),
-    ]);
-
-    // Supabase Storage에 업로드
-    setIsUploading(true);
-    try {
-      const uploadedImageData = await uploadImageToStorage(file);
-      setUploadedImage(uploadedImageData);
-      console.log('Image uploaded successfully:', uploadedImageData);
-    } catch (error) {
-      console.error('Failed to upload image:', error);
-      alert('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
-      // 업로드 실패 시 로컬 미리보기도 제거
-      setThumbnail([]);
-    } finally {
-      setIsUploading(false);
-    }
-  }, []);
-
-  const { getRootProps, getInputProps } = useDropzone({
-    onDrop,
-    accept: {
-      'image/*': [],
-    },
-    multiple: false,
-    disabled: isUploading,
-  });
-
-  useEffect(() => {
-    return () => thumbnail.forEach((file) => URL.revokeObjectURL(file.preview));
-  }, [thumbnail]);
-
-  const handleInfoClick = (infoId: string) => {
-    setSelectedInfo((prev) => (prev.includes(infoId) ? prev.filter((item) => item !== infoId) : [...prev, infoId]));
-  };
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (!uploadedImage) {
-      alert('이미지를 업로드해주세요.');
-      return;
-    }
-
-    await clientApi(`/api/host/${hostId}`, {
-      method: 'POST',
-      body: {
-        title,
-        description,
-        recruitmentMethod,
-        email,
-        capacity,
-        selectedInfo,
-        thumbnail: uploadedImage.url, // 업로드된 이미지 URL 전송
-        eventStart,
-        eventEnd,
-        zonecode,
-        address,
-        extraAddress,
-      },
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-  };
+  const { thumbnail, isUploading, getRootProps, getInputProps } = imageUpload;
+  const { handleInfoClick, openPostcode, handleSubmit } = handlers;
 
   return (
     <>
       <Script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" strategy="lazyOnload" />
       <main className="container mx-auto min-h-screen items-center justify-center p-8">
         <form id="defaultSt" className="grid grid-cols-1 gap-16 md:grid-cols-2" onSubmit={handleSubmit}>
+          {/* 이미지 영역 */}
           <div className="flex flex-col items-center justify-center space-y-8">
-            <div
-              {...getRootProps()}
-              className={`flex aspect-[4/5] w-full cursor-pointer flex-col items-center justify-center rounded-lg bg-gray-50 text-gray-400 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 ${
-                isUploading ? 'cursor-not-allowed opacity-50' : ''
-              }`}
-            >
-              <input {...getInputProps()} />
-              {thumbnail.length > 0 ? (
-                <div className="relative h-full w-full">
-                  <Image
-                    src={thumbnail[0].preview}
-                    alt="preview"
-                    width={500}
-                    height={625}
-                    className="h-full w-full object-cover"
-                  />
-                  {isUploading && (
-                    <div className="bg-opacity-50 absolute inset-0 flex items-center justify-center bg-black text-white">
-                      <div className="text-center">
-                        <div className="mb-2">업로드 중...</div>
-                        <div className="h-2 w-16 rounded-full bg-gray-300">
-                          <div className="h-2 w-8 animate-pulse rounded-full bg-white"></div>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <>
-                  <FolderPlusIcon className="h-16 w-16" />
-                  <p className="mt-2">{isUploading ? '업로드 중...' : '클릭하여 이미지 업로드 또는 드래그 앤 드롭'}</p>
-                </>
-              )}
-            </div>
+            <EventImageUpload
+              thumbnail={thumbnail}
+              isUploading={isUploading}
+              getRootProps={getRootProps}
+              getInputProps={getInputProps}
+            />
           </div>
 
           <div className="flex flex-col space-y-6">
+            {/* 이벤트명 */}
             <Input
               label={LABELS.TITLE}
               type="text"
@@ -230,41 +76,27 @@ export default function EventRegisterPage() {
               onChange={(e) => setTitle(e.target.value)}
               placeholder="개최하실 팝업 제목을 입력해주세요."
             />
+
+            {/* 본문 */}
             {/* TODO: Text area 사용자가 작성할 때 입력창이 커지거나 따로 모달로 나오던가 해서 UX를 좀 향상시켜야함 지금
           텍스트 창 너무 작음 */}
+            {/* TODO: 본문은 아마 텍스트에디터를 쓰거나 마크업언어를 쓸 수 있도록 해야 할 듯.. */}
             <Textarea
               label="이벤트에 대한 상세 설명을 입력해주세요."
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
-            {/* TODO: 이벤트 위치는 주소를 입력하면 해당 주소지의 맨 앞을 따서 가져와야겠다 e.g: 서울시 강남구 역삼동 123-45 1층 101호 -> 위치 = 서울*/}
-            <label className="mb-2 block font-medium">
-              <span className="flex items-center space-x-2">
-                <MapPinIcon className="h-5 w-5" />
-                팝업 위치
-              </span>
-            </label>
-            {address && zonecode ? (
-              <>
-                <div className="flex items-center space-x-2">
-                  <Input value={zonecode} type="text" isReadOnly className="w-sm" />
-                  <Input value={address} type="text" isReadOnly />
-                </div>
-              </>
-            ) : (
-              <div className="w-sm">
-                <Button onClick={handleOpenPostcode} type="button">
-                  주소 검색
-                </Button>
-              </div>
-            )}
 
-            <Input
-              type="text"
-              placeholder="상세 주소"
-              value={extraAddress}
-              onChange={(e) => setExtraAddress(e.target.value)}
+            {/* 장소 */}
+            <EventLocation
+              zonecode={zonecode}
+              address={address}
+              extraAddress={extraAddress}
+              setExtraAddress={setExtraAddress}
+              onOpenPostcode={openPostcode}
             />
+
+            {/* 이메일 */}
             <Input
               label={LABELS.EMAIL}
               type="email"
@@ -272,28 +104,14 @@ export default function EventRegisterPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <div className="flex items-center space-x-4">
-              <label className="font-medium whitespace-nowrap text-gray-700 dark:text-gray-300">시작일</label>
-              <Popover placement="bottom">
-                <PopoverTrigger>
-                  <Button>{eventStart ? eventStart.toString() : '시작일 선택'}</Button>
-                </PopoverTrigger>
-                <PopoverContent>
-                  <Calendar value={eventStart} onChange={setEventStart} color="primary" />
-                </PopoverContent>
-              </Popover>
+
+            {/* 이벤트 날짜(시작, 종료) */}
+            <div className="flex flex-col gap-2 lg:flex-row lg:gap-20">
+              <EventDatePicker label="시작일" value={eventStart} onChange={setEventStart} />
+              <EventDatePicker label="종료일" value={eventEnd} onChange={setEventEnd} />
             </div>
-            <div className="flex items-center space-x-4">
-              <label className="font-medium whitespace-nowrap text-gray-700 dark:text-gray-300">종료일</label>
-              <Popover placement="bottom">
-                <PopoverTrigger>
-                  <Button>{eventEnd ? eventEnd.toString() : '종료일 선택'}</Button>
-                </PopoverTrigger>
-                <PopoverContent>
-                  <Calendar value={eventEnd} onChange={setEventEnd} color="primary" />
-                </PopoverContent>
-              </Popover>
-            </div>
+
+            {/* 수용인원 */}
             <Input
               label={LABELS.PEOPLE}
               type="number"
@@ -301,37 +119,15 @@ export default function EventRegisterPage() {
               value={capacity.toString()}
               onChange={(e) => setCapacity(Number(e.target.value))}
             />
-            <div>
-              <label className="mb-2 block font-medium">참가자 모집 방법</label>
-              <CheckboxGroup
-                color="primary"
-                value={recruitmentMethod}
-                onValueChange={setRecruitmentMethod}
-                orientation="horizontal"
-                classNames={{
-                  wrapper: 'gap-20',
-                }}
-              >
-                <Checkbox value="auto">자동 신청</Checkbox>
-                <Checkbox value="manual">외부 신청 링크</Checkbox>
-              </CheckboxGroup>
-            </div>
-            <div>
-              <label className="mb-2 block font-medium">기타 안내 사항</label>
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
-                {otherInfoOptions.map((info) => (
-                  <Chip
-                    key={info.id}
-                    variant={selectedInfo.includes(info.id) ? 'solid' : 'bordered'}
-                    onClick={() => handleInfoClick(info.id)}
-                    color={selectedInfo.includes(info.id) ? 'danger' : 'default'}
-                    className="cursor-pointer"
-                  >
-                    {info.label}
-                  </Chip>
-                ))}
-              </div>
-            </div>
+
+            {/* 모집방법 */}
+            {/* TODO: 외부링크로 받을 경우에 링크 입력 할 수 있게 만들어줘야할듯 */}
+            <EventRecruitment selectedMethods={recruitmentMethod} onChange={setRecruitmentMethod} />
+
+            {/* 기타안내사항 */}
+            <EventExtraInfo options={otherInfoOptions} selectedInfo={selectedInfo} onToggle={handleInfoClick} />
+
+            {/* 폼 제출 버튼 */}
             <Button type="submit">등록하기</Button>
           </div>
         </form>

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,12 +1,10 @@
 import { ThemeSwitch } from '@/components/common/ThemeSwitch';
-import PostCode from '@/features/event/register/components/PostCode';
 
 export default function TestPage() {
   return (
     <div className="bg-red-300">
       <p>fsfsfsdf</p>
       <ThemeSwitch />
-      <PostCode />
     </div>
   );
 }

--- a/src/db/schema/events.ts
+++ b/src/db/schema/events.ts
@@ -41,14 +41,20 @@ export const insertEventSchema = createInsertSchema(events);
  */
 export const createEventSchema = z.object({
   host_id: z.string().uuid('올바른 UUID 형식이 아닙니다'),
-  thumbnail: z.string().url('올바른 이미지 URL이 아닙니다').optional(),
   title: z.string().min(1, '제목은 필수입니다').max(100, '제목은 최대 100글자'),
+  thumbnail: z.string().url('올바른 이미지 URL이 아닙니다').optional(),
+  email: z.string().email('올바른 이메일 형식이 아닙니다').optional(),
   description: z.string().max(5000, '내용은 최대 5000글자').optional(),
   address: z.string().min(1, '지역은 필수입니다'),
   event_status: z.enum(['upcoming', 'ongoing', 'ended']),
   participation_mode: z.enum(['auto', 'manual']).default('auto'),
   event_start: z.date({ required_error: '시작 날짜는 필수입니다' }),
   event_end: z.date({ required_error: '종료 날짜는 필수입니다' }),
+  capacity: z
+    .number({ invalid_type_error: '수용인원은 숫자여야 합니다.' })
+    .int('수용인원은 정수여야 합니다.')
+    .nonnegative('수용인원은 0이상의 정수여야 합니다.')
+    .optional(),
 });
 
 /**

--- a/src/db/schema/events.ts
+++ b/src/db/schema/events.ts
@@ -40,21 +40,22 @@ export const insertEventSchema = createInsertSchema(events);
  * //TODO: 수정 필요함
  */
 export const createEventSchema = z.object({
-  host_id: z.string().uuid('올바른 UUID 형식이 아닙니다'),
+  hostId: z.string().uuid('올바른 UUID 형식이 아닙니다'),
   title: z.string().min(1, '제목은 필수입니다').max(100, '제목은 최대 100글자'),
   thumbnail: z.string().url('올바른 이미지 URL이 아닙니다').optional(),
   email: z.string().email('올바른 이메일 형식이 아닙니다').optional(),
   description: z.string().max(5000, '내용은 최대 5000글자').optional(),
   address: z.string().min(1, '지역은 필수입니다'),
-  event_status: z.enum(['upcoming', 'ongoing', 'ended']),
-  participation_mode: z.enum(['auto', 'manual']).default('auto'),
-  event_start: z.date({ required_error: '시작 날짜는 필수입니다' }),
-  event_end: z.date({ required_error: '종료 날짜는 필수입니다' }),
+  eventStatus: z.enum(['upcoming', 'ongoing', 'ended']),
+  participationMode: z.enum(['auto', 'manual']).default('auto'),
+  eventStart: z.date({ required_error: '시작 날짜는 필수입니다' }),
+  eventEnd: z.date({ required_error: '종료 날짜는 필수입니다' }),
   capacity: z
     .number({ invalid_type_error: '수용인원은 숫자여야 합니다.' })
     .int('수용인원은 정수여야 합니다.')
     .nonnegative('수용인원은 0이상의 정수여야 합니다.')
     .optional(),
+  extraInfo: z.string().optional(),
 });
 
 /**
@@ -65,10 +66,10 @@ export const updateEventSchema = z.object({
   title: z.string().min(1, '제목은 필수입니다').max(100, '제목은 최대 100글자').optional(),
   description: z.string().max(5000, '내용은 최대 5000글자').optional(),
   address: z.string().min(1, '지역은 필수입니다').optional(),
-  event_status: z.enum(['upcoming', 'ongoing', 'ended']).optional(),
-  participation_mode: z.enum(['auto', 'manual']).optional(),
-  event_start: z.date().optional(),
-  event_end: z.date().optional(),
+  eventStatus: z.enum(['upcoming', 'ongoing', 'ended']).optional(),
+  participationMode: z.enum(['auto', 'manual']).optional(),
+  eventStart: z.date().optional(),
+  eventEnd: z.date().optional(),
 });
 
 /**
@@ -76,8 +77,8 @@ export const updateEventSchema = z.object({
  * @param data - 검증할 날짜 데이터
  * @throws {Error} 종료 날짜가 시작 날짜보다 이전이거나 같은 경우
  */
-export const validateEventDates = (data: { event_start?: Date; event_end?: Date }) => {
-  if (data.event_start && data.event_end && data.event_end <= data.event_start) {
+export const validateEventDates = (data: { eventStart?: Date; eventEnd?: Date }) => {
+  if (data.eventStart && data.eventEnd && data.eventEnd <= data.eventStart) {
     throw new Error('종료 날짜는 시작 날짜보다 늦어야 합니다');
   }
 };

--- a/src/features/event/register/components/DragAndDropImg.tsx
+++ b/src/features/event/register/components/DragAndDropImg.tsx
@@ -1,1 +1,0 @@
-export default function DragAndDropImg() {}

--- a/src/features/event/register/components/EventDatePicker.tsx
+++ b/src/features/event/register/components/EventDatePicker.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Button from '@/components/common/button';
+import { Calendar, DateValue, Popover, PopoverContent, PopoverTrigger } from '@heroui/react';
+
+interface EventDatePickerProps {
+  label: string;
+  value: DateValue | null;
+  onChange: (date: DateValue | null) => void;
+}
+
+export default function EventDatePicker({ label, value, onChange }: EventDatePickerProps) {
+  return (
+    <div className="flex items-center space-x-4">
+      <label className="font-medium whitespace-nowrap text-gray-700 dark:text-gray-300">{label}</label>
+      <Popover placement="bottom">
+        <PopoverTrigger>
+          <Button>{value ? value.toString() : `${label} 선택`}</Button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Calendar value={value} onChange={onChange} color="primary" />
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/features/event/register/components/EventExtraInfo.tsx
+++ b/src/features/event/register/components/EventExtraInfo.tsx
@@ -1,0 +1,33 @@
+import Chip from '@/components/common/chip';
+
+interface InfoOption {
+  id: string;
+  label: string;
+}
+
+interface EventExtraInfoProps {
+  options: InfoOption[];
+  selectedInfo: string[];
+  onToggle: (infoId: string) => void;
+}
+
+export default function EventExtraInfo({ options, selectedInfo, onToggle }: EventExtraInfoProps) {
+  return (
+    <div>
+      <label className="mb-2 block font-medium">기타 안내 사항</label>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+        {options.map((info) => (
+          <Chip
+            key={info.id}
+            variant={selectedInfo.includes(info.id) ? 'solid' : 'bordered'}
+            onClick={() => onToggle(info.id)}
+            color={selectedInfo.includes(info.id) ? 'danger' : 'default'}
+            className="cursor-pointer"
+          >
+            {info.label}
+          </Chip>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/event/register/components/EventImageUpload.tsx
+++ b/src/features/event/register/components/EventImageUpload.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { FolderPlusIcon } from '@heroicons/react/24/outline';
+import Image from 'next/image';
+
+interface FileWithPreview extends File {
+  preview: string;
+}
+
+interface EventImageUploadProps {
+  thumbnail: FileWithPreview[];
+  isUploading: boolean;
+  getRootProps: () => any;
+  getInputProps: () => any;
+}
+
+export default function EventImageUpload({
+  thumbnail,
+  isUploading,
+  getRootProps,
+  getInputProps,
+}: EventImageUploadProps) {
+  return (
+    <div
+      {...getRootProps()}
+      className={`flex aspect-[4/5] w-full cursor-pointer flex-col items-center justify-center rounded-lg bg-gray-50 text-gray-400 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700 ${
+        isUploading ? 'cursor-not-allowed opacity-50' : ''
+      }`}
+    >
+      <input {...getInputProps()} />
+      {thumbnail.length > 0 ? (
+        <div className="relative h-full w-full">
+          <Image
+            src={thumbnail[0].preview}
+            alt="preview"
+            width={500}
+            height={625}
+            className="h-full w-full object-cover"
+          />
+          {isUploading && (
+            <div className="bg-opacity-50 absolute inset-0 flex items-center justify-center bg-black text-white">
+              <div className="text-center">
+                <div className="mb-2">업로드 중...</div>
+                <div className="h-2 w-16 rounded-full bg-gray-300">
+                  <div className="h-2 w-8 animate-pulse rounded-full bg-white"></div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          <FolderPlusIcon className="h-16 w-16" />
+          <p className="mt-2">{isUploading ? '업로드 중...' : '클릭하여 이미지 업로드 또는 드래그 앤 드롭'}</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/event/register/components/EventLocation.tsx
+++ b/src/features/event/register/components/EventLocation.tsx
@@ -1,0 +1,51 @@
+import Button from '@/components/common/button';
+import Input from '@/components/common/input';
+import { MapPinIcon } from '@heroicons/react/24/outline';
+
+interface EventLocationProps {
+  zonecode: string;
+  address: string;
+  extraAddress: string;
+  setExtraAddress: (value: string) => void;
+  onOpenPostcode: () => void;
+}
+
+export default function EventLocation({
+  zonecode,
+  address,
+  extraAddress,
+  setExtraAddress,
+  onOpenPostcode,
+}: EventLocationProps) {
+  return (
+    <>
+      <label className="mb-2 block font-medium">
+        <span className="flex items-center space-x-2">
+          <MapPinIcon className="h-5 w-5" />
+          팝업 위치
+        </span>
+      </label>
+      {address && zonecode ? (
+        <>
+          <div className="flex items-center space-x-2">
+            <Input value={zonecode} type="text" isReadOnly className="w-sm" />
+            <Input value={address} type="text" isReadOnly />
+          </div>
+        </>
+      ) : (
+        <div className="w-sm">
+          <Button onClick={onOpenPostcode} type="button">
+            주소 검색
+          </Button>
+        </div>
+      )}
+
+      <Input
+        type="text"
+        placeholder="상세 주소"
+        value={extraAddress}
+        onChange={(e) => setExtraAddress(e.target.value)}
+      />
+    </>
+  );
+}

--- a/src/features/event/register/components/EventRecruitment.tsx
+++ b/src/features/event/register/components/EventRecruitment.tsx
@@ -1,0 +1,25 @@
+import { Checkbox, CheckboxGroup } from '@heroui/react';
+
+interface EventRecruitmentProps {
+  selectedMethods: string[];
+  onChange: (methods: string[]) => void;
+}
+export default function EventRecruitment({ selectedMethods, onChange }: EventRecruitmentProps) {
+  return (
+    <div>
+      <label className="mb-2 block font-medium">참가자 모집 방법</label>
+      <CheckboxGroup
+        color="primary"
+        value={selectedMethods}
+        onValueChange={onChange}
+        orientation="horizontal"
+        classNames={{
+          wrapper: 'gap-20',
+        }}
+      >
+        <Checkbox value="auto">자동 신청</Checkbox>
+        <Checkbox value="manual">외부 신청 링크</Checkbox>
+      </CheckboxGroup>
+    </div>
+  );
+}

--- a/src/features/event/register/constants/index.ts
+++ b/src/features/event/register/constants/index.ts
@@ -1,0 +1,12 @@
+export const otherInfoOptions = [
+  { id: 'parking_available', label: '주차가능' },
+  { id: 'no_parking', label: '주차불가' },
+  { id: 'kids_zone', label: '웰컴 키즈존' },
+  { id: 'no_kids_zone', label: '노키즈존' },
+  { id: 'free_admission', label: '입장료 무료' },
+  { id: 'paid_admission', label: '입장료 유료' },
+  { id: 'pets_allowed', label: '반려동물 동반가능' },
+  { id: 'no_pets_allowed', label: '반려동물 입장금지' },
+  { id: 'wifi', label: '와이파이 가능' },
+  { id: 'photography_allowed', label: '사진촬영 가능' },
+];

--- a/src/features/event/register/hooks/useDragAndDropImg.ts
+++ b/src/features/event/register/hooks/useDragAndDropImg.ts
@@ -1,0 +1,67 @@
+import { uploadImageToStorage, type UploadedImage } from '@/utils/imageUpload';
+import { useCallback, useEffect, useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+interface FileWithPreview extends File {
+  preview: string;
+}
+
+interface UseDragAndDropImgResult {
+  thumbnail: FileWithPreview[];
+  uploadedImage: UploadedImage | null;
+  isUploading: boolean;
+  getRootProps: any;
+  getInputProps: any;
+}
+
+export default function useDragAndDropImg(): UseDragAndDropImgResult {
+  // 썸네일 - 로컬 미리보기용
+  const [thumbnail, setThumbnail] = useState<FileWithPreview[]>([]);
+  // 업로드된 이미지 정보
+  const [uploadedImage, setUploadedImage] = useState<UploadedImage | null>(null);
+  // 업로드 상태
+  const [isUploading, setIsUploading] = useState(false);
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    if (acceptedFiles.length === 0) return;
+
+    const file = acceptedFiles[0];
+
+    // 로컬 미리보기 설정
+    setThumbnail([
+      Object.assign(file, {
+        preview: URL.createObjectURL(file),
+      }),
+    ]);
+
+    // Supabase Storage에 업로드
+    setIsUploading(true);
+    try {
+      const uploadedImageData = await uploadImageToStorage(file);
+      setUploadedImage(uploadedImageData);
+      console.log('Image uploaded successfully:', uploadedImageData);
+    } catch (error) {
+      console.error('Failed to upload image:', error);
+      alert('이미지 업로드에 실패했습니다. 다시 시도해주세요.');
+      // 업로드 실패 시 로컬 미리보기도 제거
+      setThumbnail([]);
+    } finally {
+      setIsUploading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => thumbnail.forEach((file) => URL.revokeObjectURL(file.preview));
+  }, [thumbnail]);
+
+  const { getRootProps, getInputProps } = useDropzone({
+    onDrop,
+    accept: {
+      'image/*': [],
+    },
+    multiple: false,
+    disabled: isUploading,
+  });
+
+  return { thumbnail, uploadedImage, isUploading, getRootProps, getInputProps };
+}

--- a/src/features/event/register/hooks/useEventRegisterForm.ts
+++ b/src/features/event/register/hooks/useEventRegisterForm.ts
@@ -1,0 +1,135 @@
+import useDragAndDropImg from '@/features/event/register/hooks/useDragAndDropImg';
+import usePostcode from '@/features/event/register/hooks/usePostCode';
+import { clientApi } from '@/libs/api';
+import { DateValue } from '@heroui/react';
+import { useCallback, useState } from 'react';
+
+interface AddressData {
+  zonecode: string;
+  address: string;
+  extraAddress: string;
+}
+
+export default function useEventRegisterForm(hostId: string | undefined) {
+  const [title, setTitle] = useState(''); // 제목
+  const [description, setDescription] = useState(''); // 본문
+  const [email, setEmail] = useState(''); // 이메일
+  const [recruitmentMethod, setRecruitmentMethod] = useState<string[]>([]); // 모집 방법
+  const [capacity, setCapacity] = useState<number>(0); // 참가자 수
+  const [selectedInfo, setSelectedInfo] = useState<string[]>([]); // 기타안내사항 선택 상태
+
+  // 날짜 상태
+  const [eventStart, setEventStart] = useState<DateValue | null>(null);
+  const [eventEnd, setEventEnd] = useState<DateValue | null>(null);
+
+  // 주소 상태
+  const [zonecode, setZonecode] = useState(''); // 우편번호
+  const [address, setAddress] = useState(''); // 주소
+  const [extraAddress, setExtraAddress] = useState(''); // 상세 주소
+
+  // 이미지 드로그앤드롭 훅
+  const { thumbnail, uploadedImage, isUploading, getRootProps, getInputProps } = useDragAndDropImg();
+
+  // 우편번호 검색 콜백
+  const handleAddressComplete = useCallback((data: AddressData) => {
+    // NOTE: 디버깅할 때 쓸 것, 선택된 주소를 alert으로 표시
+    // alert(`우편번호: ${data.zonecode}\n주소: ${fullAddress}`);
+
+    setAddress(data.address);
+    setZonecode(data.zonecode);
+    setExtraAddress(data.extraAddress);
+  }, []);
+
+  // 우편번호 오픈 훅
+  const openPostcode = usePostcode(handleAddressComplete);
+
+  // 기타 안내 사항 선택
+  const handleInfoClick = useCallback((infoId: string) => {
+    setSelectedInfo((prev) => (prev.includes(infoId) ? prev.filter((item) => item !== infoId) : [...prev, infoId]));
+  }, []);
+
+  //제출 함수
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+
+      if (!uploadedImage) {
+        alert('이미지를 업로드해주세요.');
+        return;
+      }
+
+      await clientApi(`/api/host/${hostId}`, {
+        method: 'POST',
+        body: {
+          title,
+          description,
+          recruitmentMethod,
+          email,
+          capacity,
+          selectedInfo,
+          thumbnail: uploadedImage.url, // 업로드된 이미지 URL 전송
+          eventStart,
+          eventEnd,
+          zonecode,
+          address,
+          extraAddress,
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    },
+    [
+      address,
+      capacity,
+      description,
+      email,
+      eventEnd,
+      eventStart,
+      hostId,
+      recruitmentMethod,
+      selectedInfo,
+      thumbnail,
+      uploadedImage,
+      zonecode,
+      title,
+      extraAddress,
+    ]
+  );
+
+  return {
+    fields: {
+      title,
+      setTitle,
+      description,
+      setDescription,
+      email,
+      setEmail,
+      recruitmentMethod,
+      setRecruitmentMethod,
+      capacity,
+      setCapacity,
+      selectedInfo,
+      eventStart,
+      setEventStart,
+      eventEnd,
+      setEventEnd,
+      zonecode,
+      address,
+      extraAddress,
+      setExtraAddress,
+    },
+    imageUpload: {
+      thumbnail,
+      uploadedImage,
+      isUploading,
+      getRootProps,
+      getInputProps,
+    },
+    handlers: {
+      handleInfoClick,
+      openPostcode,
+      handleSubmit,
+    },
+  };
+}

--- a/src/features/event/register/hooks/usePostCode.ts
+++ b/src/features/event/register/hooks/usePostCode.ts
@@ -1,7 +1,8 @@
 'use client';
+
+import { useCallback } from 'react';
+
 // TODO: 이거 기반으로 이제 만들면된다.
-import Button from '@/components/common/button';
-import Script from 'next/script';
 
 declare global {
   interface Window {
@@ -9,8 +10,14 @@ declare global {
   }
 }
 
-export default function PostCode() {
-  const handleOpenPostcode = () => {
+interface PostcodeData {
+  zonecode: string;
+  address: string;
+  extraAddress: string;
+}
+
+export default function usePostcode(onComplete: (data: PostcodeData) => void) {
+  const openPostcode = useCallback(() => {
     if (typeof window.daum === 'undefined' || typeof window.daum.Postcode === 'undefined') {
       alert('Daum Postcode 서비스가 로드되지 않았습니다.');
       return;
@@ -19,7 +26,6 @@ export default function PostCode() {
     new window.daum.Postcode({
       oncomplete: function (data: any) {
         let fullAddress = data.address;
-        console.log(data);
         let extraAddress = '';
 
         if (data.addressType === 'R') {
@@ -32,20 +38,14 @@ export default function PostCode() {
           fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
         }
 
-        // 선택된 주소를 alert으로 표시
-        alert(`우편번호: ${data.zonecode}\n주소: ${fullAddress}`);
+        onComplete({
+          zonecode: data.zonecode,
+          address: fullAddress,
+          extraAddress,
+        });
       },
     }).open();
-  };
+  }, [onComplete]);
 
-  return (
-    <>
-      <Script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js" strategy="lazyOnload" />
-      <div className="w-sm">
-        <Button onClick={handleOpenPostcode} type="button">
-          주소 검색
-        </Button>
-      </div>
-    </>
-  );
+  return openPostcode;
 }


### PR DESCRIPTION
## ✨ 작업 개요

1. event-register 컴포넌트 분리
2. 이벤트 등록시 이벤트 기간에 따라 이벤트 상태 분류해서 적용
## 📌 변경사항 요약

1. EventRegister페이지컴포넌트 수정
    - EventDatePicker : 시작일 종료일을 선택하는 UI 컴포넌트
    - EventExtraInfo : 기타 안내사항 UI 컴포넌트
    - EventImageUpload : 이미지 영역 UI 컴포넌트
    - EventLocation : 주소검색 UI 컴포넌트 
    - EventRecruitment : 모집방법 UI 컴포넌트
    - constants : 기타 안내사항 라벨 상수파일로 분리
    - useDragAndDrop : 이미지 드래그앤드롭 기능 훅
    - useEventRegisterForm : 이벤트 등록 폼을 다루는 훅
    - usePostCode : 우편번호 검색 기능 훅
    - 
3. api/host/[hostId] 의 route.ts 파일 : zod 검증 호출 및 적용 -> DB에 반영
    - computeEventStatus: 이벤트 시작일이 등록일기준 이후면 'upcoming', 등록일이 이벤트 기간에 포함되어 있으면 'ongoing', 나머지는 'ended'로 분류
    - rawData를 받아서 validatedData로 변환, 검증된 데이터를 db에 삽입
4. 우편번호 테스트 페이지(X)
5. zod 검증 필드 추가, 필드명 카멜케이스로 통일  
6. EventRegister에서 분리된 컴포넌트 & 훅 (1번에 나열)

## 📝 참고사항

1차적으로 feature 폴더를 기준으로 분리했습니다. 각 파일의 TODO 작업도 곧 진행하겠습니다.  