### PR TITLE
Refactor/event detail 1차 리팩토링

### DIFF
--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import Button from '@/components/common/button';
+import Chip from '@/components/common/chip';
+import ShareButton from '@/features/event/detail/components/ShareButton';
+import type { EventData } from '@/types/event';
+import type { User } from '@/types/user';
+import { formatDate } from '@/utils/dateformatter';
+import {
+  ArrowTopRightOnSquareIcon,
+  BanknotesIcon,
+  ChevronDoubleRightIcon,
+  HeartIcon,
+  InformationCircleIcon,
+  MapPinIcon,
+} from '@heroicons/react/24/outline';
+import { Divider, Image } from '@heroui/react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import NextImage from 'next/image';
+import Link from 'next/link';
+
+interface EventDetailProps {
+  event: EventData;
+  host: User;
+}
+
+export default function EventDetailPage({ event, host }: EventDetailProps) {
+  const imgSrc = Array.isArray(event.thumbnail) ? event.thumbnail[0] : event.thumbnail;
+  // 달력 아이콘(커스텀)
+  const start = event.eventStart;
+  const month = format(start, 'M', { locale: ko });
+  const day = format(start, 'd', { locale: ko });
+  // 주소 쪼개기
+  const place = event?.address?.split(',').map((s: string) => s.trim())[1];
+  // 기타 안내 사항
+  // NOTE: 아이콘이랑 같이 띄워주면 좋을듯
+  const extraInfos: string[] =
+    typeof event.extraInfo === 'string'
+      ? event.extraInfo
+          .split(',')
+          .map((s: string) => s.trim())
+          .filter(Boolean)
+      : Array.isArray(event.extraInfo)
+        ? event.extraInfo
+        : [];
+  return (
+    // NOTE: 시맨틱하게 바꿀 수 있는 요소들 리팩토링 필요
+    <>
+      <section>
+        {/* 이미지 포스터(썸네일) */}
+        <div className="mb-6 flex justify-center">
+          <Image isBlurred as={NextImage} src={imgSrc} alt={event.title} width={400} height={500} />
+        </div>
+        {/* 타이틀 */}
+        <div className="flex items-baseline space-x-3">
+          <strong className="text-3xl drop-shadow-lg">{event.title}</strong>
+          {/* 1024px 미만 반응형: 주최자명 */}
+          <Link href="/host-center" className="inline-flex items-center space-x-1 text-sm text-gray-500 lg:hidden">
+            <span className="truncate font-medium">{host.name}</span>
+            <ChevronDoubleRightIcon className="h-4 w-4" />
+          </Link>
+        </div>
+        <Divider className="my-4" />
+        {/* 일시 */}
+        <div className="mb-2 flex items-center gap-4">
+          <div className="flex h-8 w-8 flex-col overflow-hidden rounded border text-center shadow-sm">
+            <div className="bg-gray-600/30 py-[2px] text-[8px] leading-none text-gray-500">{month}월</div>
+            <div className="bg-transparent py-[1px] text-xs font-semibold">{day}</div>
+          </div>
+          <p className="text-sm text-gray-500">
+            {formatDate(event.eventStart)} ~ {formatDate(event.eventEnd)}
+          </p>
+        </div>
+        {/* 장소 */}
+        <div className="mb-2 flex flex-row items-center gap-4">
+          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
+            <MapPinIcon className="h-5 w-5 text-gray-500" />
+          </div>
+          <Link
+            href={`http://map.kakao.com/link/search/${place}`}
+            target="_blank"
+            className="inline-flex items-center space-x-1 text-sm text-gray-500"
+          >
+            <p>{place}</p>
+            <ArrowTopRightOnSquareIcon className="h-5 w-5 lg:hidden" />
+          </Link>
+        </div>
+        {/* 비용 */}
+        <div className="mb-2 flex flex-row items-center gap-4">
+          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
+            <BanknotesIcon className="h-5 w-5 text-gray-500" />
+          </div>
+          <p className="text-sm text-gray-500">무료</p>
+        </div>
+        {/* 기타 정보 */}
+        <div className="mb-2 flex flex-row items-center gap-4">
+          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
+            <InformationCircleIcon className="h-5 w-5 text-gray-500" />
+          </div>
+          {extraInfos.map((info, index) => (
+            <Chip key={index}>{info}</Chip>
+          ))}
+        </div>
+        <Divider className="my-4" />
+        {/* 본문 */}
+        <div className="mb-14">
+          <p className="mb-2 text-lg font-semibold">이벤트 소개</p>
+          {/* Glassmorphic Card */}
+          <div className="relative overflow-hidden rounded-3xl border border-white/30 bg-white/20 p-6 shadow-xl backdrop-blur-lg">
+            {/* Glossy Sheen */}
+            <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
+            {/* 실제 본문 */}
+            <p className="relative text-sm leading-relaxed text-gray-800">{event.description}</p>
+          </div>
+        </div>
+      </section>
+      {/* 1024px 미만 반응형: 하단 바 */}
+      <div className="fixed inset-x-4 bottom-4 z-50 flex items-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
+        {/* 가격 정보 */}
+        <div className="flex-1 flex-shrink-0 flex-col items-center justify-center">
+          <p className="text-xs text-gray-500">티켓 가격</p>
+          <p className="text-lg font-semibold text-gray-800">무료</p>
+        </div>
+        {/* 버튼 그룹  */}
+        <div className="ml-auto flex flex-1 flex-row items-center space-x-3">
+          {/* 관심 팝업(하트) */}
+          <Button
+            isIconOnly
+            className="flex items-center justify-center rounded-lg border border-white/30 bg-white/30 shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white"
+          >
+            <HeartIcon className="h-5 w-5 text-red-500" />
+          </Button>
+          {/* 링크 공유 */}
+          <ShareButton />
+          {/* 신청 버튼 */}
+          <Link href={`/event/${event.id}/participate`}>
+            <Button className="flex-1 rounded-lg bg-gradient-to-r from-pink-400 to-blue-400 font-semibold text-white shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white">
+              <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
+              신청하기
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -3,11 +3,11 @@
 import EventDescription from '@/features/event/detail/components/EventDescription';
 import EventInfoList from '@/features/event/detail/components/EventInfoList';
 import EventMobileBar from '@/features/event/detail/components/EventMobileBar';
+import EventPoster from '@/features/event/detail/components/EventPoster';
 import EventTitle from '@/features/event/detail/components/EventTitle';
 import type { EventData } from '@/types/event';
 import type { User } from '@/types/user';
-import { Divider, Image } from '@heroui/react';
-import NextImage from 'next/image';
+import { Divider } from '@heroui/react';
 
 interface EventDetailProps {
   event: EventData;
@@ -18,27 +18,22 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
   const imgSrc = Array.isArray(event.thumbnail) ? event.thumbnail[0] : event.thumbnail;
 
   return (
-    // NOTE: 시맨틱하게 바꿀 수 있는 요소들 리팩토링 필요
     <>
-      <section>
-        {/* 이미지 포스터(썸네일) */}
-        <div className="mb-6 flex justify-center">
-          <Image isBlurred as={NextImage} src={imgSrc} alt={event.title} width={400} height={500} />
-        </div>
-        {/* 타이틀 */}
-        <EventTitle title={event.title} hostName={host.name} hostLink="/host-center" />
-        <Divider className="my-4" />
-        {/* 이벤트 정보 */}
-        <EventInfoList
-          eventStart={event.eventStart}
-          eventEnd={event.eventEnd}
-          address={event.address}
-          extraInfo={event.extraInfo}
-        />
-        <Divider className="my-4" />
-        {/* 본문 */}
-        <EventDescription description={event.description} />
-      </section>
+      {/* 이미지 포스터(썸네일) */}
+      <EventPoster src={imgSrc} alt={event.title} />
+      {/* 타이틀 */}
+      <EventTitle title={event.title} hostName={host.name} hostLink="/host-center" />
+      <Divider className="my-4" />
+      {/* 이벤트 정보 */}
+      <EventInfoList
+        eventStart={event.eventStart}
+        eventEnd={event.eventEnd}
+        address={event.address}
+        extraInfo={event.extraInfo}
+      />
+      <Divider className="my-4" />
+      {/* 본문 */}
+      <EventDescription description={event.description} />
       {/* 1024px 미만 반응형: 하단 바 */}
       {/* TODO: 관심토글 기능 구현해야함 */}
       <EventMobileBar priceLabel="무료" eventId={event.id} />

--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -1,24 +1,14 @@
 'use client';
 
 import Button from '@/components/common/button';
-import Chip from '@/components/common/chip';
 import ShareButton from '@/features/event/detail/components/ShareButton';
 import type { EventData } from '@/types/event';
 import type { User } from '@/types/user';
-import { formatDate } from '@/utils/dateformatter';
-import {
-  ArrowTopRightOnSquareIcon,
-  BanknotesIcon,
-  ChevronDoubleRightIcon,
-  HeartIcon,
-  InformationCircleIcon,
-  MapPinIcon,
-} from '@heroicons/react/24/outline';
+import { ChevronDoubleRightIcon, HeartIcon } from '@heroicons/react/24/outline';
 import { Divider, Image } from '@heroui/react';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
 import NextImage from 'next/image';
 import Link from 'next/link';
+import InfoList from '../features/event/detail/components/InfoList';
 
 interface EventDetailProps {
   event: EventData;
@@ -27,23 +17,7 @@ interface EventDetailProps {
 
 export default function EventDetailPage({ event, host }: EventDetailProps) {
   const imgSrc = Array.isArray(event.thumbnail) ? event.thumbnail[0] : event.thumbnail;
-  // 달력 아이콘(커스텀)
-  const start = event.eventStart;
-  const month = format(start, 'M', { locale: ko });
-  const day = format(start, 'd', { locale: ko });
-  // 주소 쪼개기
-  const place = event?.address?.split(',').map((s: string) => s.trim())[1];
-  // 기타 안내 사항
-  // NOTE: 아이콘이랑 같이 띄워주면 좋을듯
-  const extraInfos: string[] =
-    typeof event.extraInfo === 'string'
-      ? event.extraInfo
-          .split(',')
-          .map((s: string) => s.trim())
-          .filter(Boolean)
-      : Array.isArray(event.extraInfo)
-        ? event.extraInfo
-        : [];
+
   return (
     // NOTE: 시맨틱하게 바꿀 수 있는 요소들 리팩토링 필요
     <>
@@ -62,46 +36,13 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
           </Link>
         </div>
         <Divider className="my-4" />
-        {/* 일시 */}
-        <div className="mb-2 flex items-center gap-4">
-          <div className="flex h-8 w-8 flex-col overflow-hidden rounded border text-center shadow-sm">
-            <div className="bg-gray-600/30 py-[2px] text-[8px] leading-none text-gray-500">{month}월</div>
-            <div className="bg-transparent py-[1px] text-xs font-semibold">{day}</div>
-          </div>
-          <p className="text-sm text-gray-500">
-            {formatDate(event.eventStart)} ~ {formatDate(event.eventEnd)}
-          </p>
-        </div>
-        {/* 장소 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <MapPinIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          <Link
-            href={`http://map.kakao.com/link/search/${place}`}
-            target="_blank"
-            className="inline-flex items-center space-x-1 text-sm text-gray-500"
-          >
-            <p>{place}</p>
-            <ArrowTopRightOnSquareIcon className="h-5 w-5 lg:hidden" />
-          </Link>
-        </div>
-        {/* 비용 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <BanknotesIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          <p className="text-sm text-gray-500">무료</p>
-        </div>
-        {/* 기타 정보 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <InformationCircleIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          {extraInfos.map((info, index) => (
-            <Chip key={index}>{info}</Chip>
-          ))}
-        </div>
+        {/* 이벤트 정보 */}
+        <InfoList
+          eventStart={event.eventStart}
+          eventEnd={event.eventEnd}
+          address={event.address}
+          extraInfo={event.extraInfo}
+        />
         <Divider className="my-4" />
         {/* 본문 */}
         <div className="mb-14">

--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import Button from '@/components/common/button';
 import EventDescription from '@/features/event/detail/components/EventDescription';
 import EventInfoList from '@/features/event/detail/components/EventInfoList';
-import ShareButton from '@/features/event/detail/components/ShareButton';
+import EventMobileBar from '@/features/event/detail/components/EventMobileBar';
 import type { EventData } from '@/types/event';
 import type { User } from '@/types/user';
-import { ChevronDoubleRightIcon, HeartIcon } from '@heroicons/react/24/outline';
+import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Divider, Image } from '@heroui/react';
 import NextImage from 'next/image';
 import Link from 'next/link';
@@ -49,32 +48,8 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
         <EventDescription description={event.description} />
       </section>
       {/* 1024px 미만 반응형: 하단 바 */}
-      <div className="fixed inset-x-4 bottom-4 z-50 flex items-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
-        {/* 가격 정보 */}
-        <div className="flex-1 flex-shrink-0 flex-col items-center justify-center">
-          <p className="text-xs text-gray-500">티켓 가격</p>
-          <p className="text-lg font-semibold text-gray-800">무료</p>
-        </div>
-        {/* 버튼 그룹  */}
-        <div className="ml-auto flex flex-1 flex-row items-center space-x-3">
-          {/* 관심 팝업(하트) */}
-          <Button
-            isIconOnly
-            className="flex items-center justify-center rounded-lg border border-white/30 bg-white/30 shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white"
-          >
-            <HeartIcon className="h-5 w-5 text-red-500" />
-          </Button>
-          {/* 링크 공유 */}
-          <ShareButton />
-          {/* 신청 버튼 */}
-          <Link href={`/event/${event.id}/participate`}>
-            <Button className="flex-1 rounded-lg bg-gradient-to-r from-pink-400 to-blue-400 font-semibold text-white shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white">
-              <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
-              신청하기
-            </Button>
-          </Link>
-        </div>
-      </div>
+      {/* TODO: 관심토글 기능 구현해야함 */}
+      <EventMobileBar priceLabel="무료" eventId={event.id} />
     </>
   );
 }

--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -3,12 +3,11 @@
 import EventDescription from '@/features/event/detail/components/EventDescription';
 import EventInfoList from '@/features/event/detail/components/EventInfoList';
 import EventMobileBar from '@/features/event/detail/components/EventMobileBar';
+import EventTitle from '@/features/event/detail/components/EventTitle';
 import type { EventData } from '@/types/event';
 import type { User } from '@/types/user';
-import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Divider, Image } from '@heroui/react';
 import NextImage from 'next/image';
-import Link from 'next/link';
 
 interface EventDetailProps {
   event: EventData;
@@ -27,14 +26,7 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
           <Image isBlurred as={NextImage} src={imgSrc} alt={event.title} width={400} height={500} />
         </div>
         {/* 타이틀 */}
-        <div className="flex items-baseline space-x-3">
-          <strong className="text-3xl drop-shadow-lg">{event.title}</strong>
-          {/* 1024px 미만 반응형: 주최자명 */}
-          <Link href="/host-center" className="inline-flex items-center space-x-1 text-sm text-gray-500 lg:hidden">
-            <span className="truncate font-medium">{host.name}</span>
-            <ChevronDoubleRightIcon className="h-4 w-4" />
-          </Link>
-        </div>
+        <EventTitle title={event.title} hostName={host.name} hostLink="/host-center" />
         <Divider className="my-4" />
         {/* 이벤트 정보 */}
         <EventInfoList

--- a/src/_pages/EventDetailPage.tsx
+++ b/src/_pages/EventDetailPage.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import Button from '@/components/common/button';
+import EventDescription from '@/features/event/detail/components/EventDescription';
+import EventInfoList from '@/features/event/detail/components/EventInfoList';
 import ShareButton from '@/features/event/detail/components/ShareButton';
 import type { EventData } from '@/types/event';
 import type { User } from '@/types/user';
@@ -8,7 +10,6 @@ import { ChevronDoubleRightIcon, HeartIcon } from '@heroicons/react/24/outline';
 import { Divider, Image } from '@heroui/react';
 import NextImage from 'next/image';
 import Link from 'next/link';
-import InfoList from '../features/event/detail/components/InfoList';
 
 interface EventDetailProps {
   event: EventData;
@@ -37,7 +38,7 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
         </div>
         <Divider className="my-4" />
         {/* 이벤트 정보 */}
-        <InfoList
+        <EventInfoList
           eventStart={event.eventStart}
           eventEnd={event.eventEnd}
           address={event.address}
@@ -45,16 +46,7 @@ export default function EventDetailPage({ event, host }: EventDetailProps) {
         />
         <Divider className="my-4" />
         {/* 본문 */}
-        <div className="mb-14">
-          <p className="mb-2 text-lg font-semibold">이벤트 소개</p>
-          {/* Glassmorphic Card */}
-          <div className="relative overflow-hidden rounded-3xl border border-white/30 bg-white/20 p-6 shadow-xl backdrop-blur-lg">
-            {/* Glossy Sheen */}
-            <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
-            {/* 실제 본문 */}
-            <p className="relative text-sm leading-relaxed text-gray-800">{event.description}</p>
-          </div>
-        </div>
+        <EventDescription description={event.description} />
       </section>
       {/* 1024px 미만 반응형: 하단 바 */}
       <div className="fixed inset-x-4 bottom-4 z-50 flex items-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">

--- a/src/app/event/[eventId]/@sidebar/page.tsx
+++ b/src/app/event/[eventId]/@sidebar/page.tsx
@@ -1,29 +1,25 @@
 import EventMapPanel from '@/features/event/detail/components/EventMapPanel';
-import { clientApi } from '@/libs/api';
-import type { EventData } from '@/types/event';
+import { getEventById } from '@/features/event/detail/services/getEventById';
+import { getHostByEventId } from '@/features/event/detail/services/getHostByEventId';
 import { notFound } from 'next/navigation';
 
 interface Props {
   params: Promise<{ eventId: string }>;
 }
-interface UserData {
-  id: string;
-  name: string;
-}
 export default async function Page({ params }: Props) {
   const { eventId } = await params;
-  const event = await clientApi<EventData>(`/api/events/${eventId}`, { method: 'GET' });
-  const place = event.address.split(',').map((s: string) => s.trim())[1];
-
-  const host = await clientApi<UserData>(`/api/users/${event.hostId}`, { method: 'GET' });
-  const hostName = host[0].name;
-
+  // 이벤트 조회
+  const event = await getEventById(eventId);
   if (!event) return notFound();
+  // 호스트 조회
+  const host = await getHostByEventId(event.hostId);
   if (!host) return notFound();
+  // 주소 parsing
+  const place = event?.address?.split(',').map((s: string) => s.trim())[1];
 
   return (
-    <div className="flex flex-col gap-4">
-      <EventMapPanel address={place} organizer={hostName} />
+    <div className="mb-10 flex flex-col gap-4">
+      <EventMapPanel address={place} organizer={host.name} />
     </div>
   );
 }

--- a/src/app/event/[eventId]/@sidebar/page.tsx
+++ b/src/app/event/[eventId]/@sidebar/page.tsx
@@ -1,12 +1,11 @@
 import EventMapPanel from '@/features/event/detail/components/EventMapPanel';
 import { getEventById } from '@/features/event/detail/services/getEventById';
 import { getHostByEventId } from '@/features/event/detail/services/getHostByEventId';
+import type { PageProps } from '@/features/event/detail/types';
+import { getAddressPart } from '@/utils/adress';
 import { notFound } from 'next/navigation';
 
-interface Props {
-  params: Promise<{ eventId: string }>;
-}
-export default async function Page({ params }: Props) {
+export default async function Page({ params }: PageProps) {
   const { eventId } = await params;
   // 이벤트 조회
   const event = await getEventById(eventId);
@@ -15,7 +14,7 @@ export default async function Page({ params }: Props) {
   const host = await getHostByEventId(event.hostId);
   if (!host) return notFound();
   // 주소 parsing
-  const place = event?.address?.split(',').map((s: string) => s.trim())[1];
+  const place = getAddressPart(event.address!, 1);
 
   return (
     <div className="mb-10 flex flex-col gap-4">

--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -1,17 +1,20 @@
 import EventDetailPage from '@/_pages/EventDetailPage';
-import { clientApi } from '@/libs/api';
-import type { EventData } from '@/types/event';
-import type { User } from '@/types/user';
+import { getEventById } from '@/features/event/detail/services/getEventById';
+import { getHostByEventId } from '@/features/event/detail/services/getHostByEventId';
+import { notFound } from 'next/navigation';
 
 interface Props {
-  params: { eventId: string };
+  params: Promise<{ eventId: string }>;
 }
 
 export default async function Page({ params }: Props) {
   const { eventId } = await params;
-  const event = await clientApi<EventData>(`/api/events/${eventId}`, { method: 'GET' });
-  const hostList = await clientApi<User[]>(`/api/users/${event.hostId}`, { method: 'GET' });
-  const host = hostList[0];
+
+  const event = await getEventById(eventId);
+  if (!event) notFound();
+
+  const host = await getHostByEventId(event.hostId);
+  if (!host) notFound();
 
   return <EventDetailPage event={event} host={host} />;
 }

--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -1,13 +1,10 @@
 import EventDetailPage from '@/_pages/EventDetailPage';
 import { getEventById } from '@/features/event/detail/services/getEventById';
 import { getHostByEventId } from '@/features/event/detail/services/getHostByEventId';
+import type { PageProps } from '@/features/event/detail/types';
 import { notFound } from 'next/navigation';
 
-interface Props {
-  params: Promise<{ eventId: string }>;
-}
-
-export default async function Page({ params }: Props) {
+export default async function Page({ params }: PageProps) {
   const { eventId } = await params;
 
   const event = await getEventById(eventId);

--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -1,159 +1,17 @@
-import Button from '@/components/common/button';
-import Chip from '@/components/common/chip';
-import ShareButton from '@/features/event/detail/components/ShareButton';
+import EventDetailPage from '@/_pages/EventDetailPage';
 import { clientApi } from '@/libs/api';
 import type { EventData } from '@/types/event';
-import { formatDate } from '@/utils/dateformatter';
-import {
-  ArrowTopRightOnSquareIcon,
-  BanknotesIcon,
-  ChevronDoubleRightIcon,
-  HeartIcon,
-  InformationCircleIcon,
-  MapPinIcon,
-} from '@heroicons/react/24/outline';
-import { Image } from '@heroui/image';
-import { Divider } from '@heroui/react';
-import { format } from 'date-fns';
-import { ko } from 'date-fns/locale';
-import NextImage from 'next/image';
-import Link from 'next/link';
+import type { User } from '@/types/user';
 
 interface Props {
   params: { eventId: string };
 }
-interface UserData {
-  id: string;
-  name: string;
-}
+
 export default async function Page({ params }: Props) {
   const { eventId } = await params;
-  // 이벤트 정보 조회
   const event = await clientApi<EventData>(`/api/events/${eventId}`, { method: 'GET' });
-  const imgSrc = Array.isArray(event.thumbnail) ? event.thumbnail[0] : event.thumbnail;
+  const hostList = await clientApi<User[]>(`/api/users/${event.hostId}`, { method: 'GET' });
+  const host = hostList[0];
 
-  // 달력 아이콘(커스텀)
-  const start = event.eventStart;
-  const month = format(start, 'M', { locale: ko });
-  const day = format(start, 'd', { locale: ko });
-
-  // 주소 쪼개기
-  const place = event.address.split(',').map((s: string) => s.trim())[1];
-
-  // 기타 안내 사항
-  // NOTE: 아이콘이랑 같이 띄워주면 좋을듯
-  const extraInfos: string[] =
-    typeof event.extraInfo === 'string'
-      ? event.extraInfo
-          .split(',')
-          .map((s: string) => s.trim())
-          .filter(Boolean)
-      : Array.isArray(event.extraInfo)
-        ? event.extraInfo
-        : [];
-
-  // 주최자 이름
-  const host = await clientApi<UserData>(`/api/users/${event.hostId}`, { method: 'GET' });
-  const hostName = host[0].name;
-
-  return (
-    // NOTE: 시맨틱하게 바꿀 수 있는 요소들 리팩토링 필요
-    <>
-      <section>
-        {/* 이미지 포스터(썸네일) */}
-        <div className="mb-6 flex justify-center">
-          <Image isBlurred as={NextImage} src={imgSrc} alt={event.title} width={400} height={500} />
-        </div>
-        {/* 타이틀 */}
-        <div className="flex items-baseline space-x-3">
-          <strong className="text-3xl drop-shadow-lg">{event.title}</strong>
-          {/* 1024px 미만 반응형: 주최자명 */}
-          <Link href="/host-center" className="inline-flex items-center space-x-1 text-sm text-gray-500 lg:hidden">
-            <span className="truncate font-medium">{hostName}</span>
-            <ChevronDoubleRightIcon className="h-4 w-4" />
-          </Link>
-        </div>
-        <Divider className="my-4" />
-        {/* 일시 */}
-        <div className="mb-2 flex items-center gap-4">
-          <div className="flex h-8 w-8 flex-col overflow-hidden rounded border text-center shadow-sm">
-            <div className="bg-gray-600/30 py-[2px] text-[8px] leading-none text-gray-500">{month}월</div>
-            <div className="bg-transparent py-[1px] text-xs font-semibold">{day}</div>
-          </div>
-          <p className="text-sm text-gray-500">
-            {formatDate(event.eventStart)} ~ {formatDate(event.eventEnd)}
-          </p>
-        </div>
-        {/* 장소 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <MapPinIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          <Link
-            href={`http://map.kakao.com/link/search/${place}`}
-            target="_blank"
-            className="inline-flex items-center space-x-1 text-sm text-gray-500"
-          >
-            <p>{place}</p>
-            <ArrowTopRightOnSquareIcon className="h-5 w-5 lg:hidden" />
-          </Link>
-        </div>
-        {/* 비용 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <BanknotesIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          <p className="text-sm text-gray-500">무료</p>
-        </div>
-        {/* 기타 정보 */}
-        <div className="mb-2 flex flex-row items-center gap-4">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border-none">
-            <InformationCircleIcon className="h-5 w-5 text-gray-500" />
-          </div>
-          {extraInfos.map((info, index) => (
-            <Chip key={index}>{info}</Chip>
-          ))}
-        </div>
-        <Divider className="my-4" />
-        {/* 본문 */}
-        <div className="mb-14">
-          <p className="mb-2 text-lg font-semibold">이벤트 소개</p>
-          {/* Glassmorphic Card */}
-          <div className="relative overflow-hidden rounded-3xl border border-white/30 bg-white/20 p-6 shadow-xl backdrop-blur-lg">
-            {/* Glossy Sheen */}
-            <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
-            {/* 실제 본문 */}
-            <p className="relative text-sm leading-relaxed text-gray-800">{event.description}</p>
-          </div>
-        </div>
-      </section>
-      {/* 1024px 미만 반응형: 하단 바 */}
-      <div className="fixed inset-x-4 bottom-4 z-50 flex items-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
-        {/* 가격 정보 */}
-        <div className="flex-1 flex-shrink-0 flex-col items-center justify-center">
-          <p className="text-xs text-gray-500">티켓 가격</p>
-          <p className="text-lg font-semibold text-gray-800">무료</p>
-        </div>
-        {/* 버튼 그룹  */}
-        <div className="ml-auto flex flex-1 flex-row items-center space-x-3">
-          {/* 관심 팝업(하트) */}
-          <Button
-            isIconOnly
-            className="flex items-center justify-center rounded-lg border border-white/30 bg-white/30 shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white"
-          >
-            <HeartIcon className="h-5 w-5 text-red-500" />
-          </Button>
-          {/* 링크 공유 */}
-          <ShareButton />
-          {/* 신청 버튼 */}
-          <Link href={`/event/${eventId}/participate`}>
-            <Button className="flex-1 rounded-lg bg-gradient-to-r from-pink-400 to-blue-400 font-semibold text-white shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white">
-              <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
-              신청하기
-            </Button>
-          </Link>
-        </div>
-      </div>
-    </>
-  );
+  return <EventDetailPage event={event} host={host} />;
 }

--- a/src/features/event/detail/components/EventActionButtons.tsx
+++ b/src/features/event/detail/components/EventActionButtons.tsx
@@ -2,8 +2,7 @@
 
 import Button from '@/components/common/button';
 import ShareButton from '@/features/event/detail/components/ShareButton';
-import { useSaveStore } from '@/store/useSaveStore';
-import { saveStoreDebounce } from '@/utils/saveStoreDebounce';
+import useHandleSave from '@/hooks/useHandleSave';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
@@ -12,21 +11,12 @@ export default function EventActionButtons() {
   const { eventId } = useParams() as { eventId: string };
   const { data: session } = useSession();
   const userId = session?.user?.id;
+  const { isSaved, toggle } = useHandleSave(eventId, userId);
 
   {
     /* HACK : 관심팝업 등록이 되어 있는 상태에서 새로고침을 하면
     문구가 '관심팝업 등록' 이었다가 '취소'로 바뀜. hydration 처리를 해줘야할듯*/
   }
-  const saveStores = useSaveStore((s) => s.savedStores);
-  const toggleSaveStore = useSaveStore((s) => s.toggleSaveStore);
-
-  const isSaved = saveStores.includes(eventId);
-
-  const handleSaves = () => {
-    toggleSaveStore(eventId);
-    const isNowSaved = !saveStores.includes(eventId);
-    saveStoreDebounce(eventId, isNowSaved, userId);
-  };
 
   return (
     <section className="mt-4 flex flex-col gap-2">
@@ -34,7 +24,7 @@ export default function EventActionButtons() {
         <Button fullWidth>신청하기</Button>
       </Link>
       <div className="flex flex-row items-center gap-6">
-        <Button fullWidth onPress={handleSaves}>
+        <Button fullWidth onPress={toggle}>
           {/* NOTE: 뭔가 심심함.. */}
           {isSaved ? '관심 행사 취소' : '관심 행사 등록'}
         </Button>

--- a/src/features/event/detail/components/EventActionButtons.tsx
+++ b/src/features/event/detail/components/EventActionButtons.tsx
@@ -1,17 +1,32 @@
-// components/event/EventButtons.tsx
 'use client';
 
 import Button from '@/components/common/button';
 import ShareButton from '@/features/event/detail/components/ShareButton';
+import { useSaveStore } from '@/store/useSaveStore';
+import { saveStoreDebounce } from '@/utils/saveStoreDebounce';
+import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
-interface EventActionButtonsProps {
-  onToggleLike?: () => void;
-}
+export default function EventActionButtons() {
+  const { eventId } = useParams() as { eventId: string };
+  const { data: session } = useSession();
+  const userId = session?.user?.id;
 
-export default function EventActionButtons({ onToggleLike }: EventActionButtonsProps) {
-  const { eventId } = useParams();
+  {
+    /* HACK : 관심팝업 등록이 되어 있는 상태에서 새로고침을 하면
+    문구가 '관심팝업 등록' 이었다가 '취소'로 바뀜. hydration 처리를 해줘야할듯*/
+  }
+  const saveStores = useSaveStore((s) => s.savedStores);
+  const toggleSaveStore = useSaveStore((s) => s.toggleSaveStore);
+
+  const isSaved = saveStores.includes(eventId);
+
+  const handleSaves = () => {
+    toggleSaveStore(eventId);
+    const isNowSaved = !saveStores.includes(eventId);
+    saveStoreDebounce(eventId, isNowSaved, userId);
+  };
 
   return (
     <section className="mt-4 flex flex-col gap-2">
@@ -19,8 +34,9 @@ export default function EventActionButtons({ onToggleLike }: EventActionButtonsP
         <Button fullWidth>신청하기</Button>
       </Link>
       <div className="flex flex-row items-center gap-6">
-        <Button fullWidth onPress={onToggleLike}>
-          관심 행사
+        <Button fullWidth onPress={handleSaves}>
+          {/* NOTE: 뭔가 심심함.. */}
+          {isSaved ? '관심 행사 취소' : '관심 행사 등록'}
         </Button>
         <ShareButton />
       </div>

--- a/src/features/event/detail/components/EventActionButtons.tsx
+++ b/src/features/event/detail/components/EventActionButtons.tsx
@@ -1,0 +1,29 @@
+// components/event/EventButtons.tsx
+'use client';
+
+import Button from '@/components/common/button';
+import ShareButton from '@/features/event/detail/components/ShareButton';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+interface EventActionButtonsProps {
+  onToggleLike?: () => void;
+}
+
+export default function EventActionButtons({ onToggleLike }: EventActionButtonsProps) {
+  const { eventId } = useParams();
+
+  return (
+    <section className="mt-4 flex flex-col gap-2">
+      <Link href={`/event/${eventId}/participate`}>
+        <Button fullWidth>신청하기</Button>
+      </Link>
+      <div className="flex flex-row items-center gap-6">
+        <Button fullWidth onPress={onToggleLike}>
+          관심 행사
+        </Button>
+        <ShareButton />
+      </div>
+    </section>
+  );
+}

--- a/src/features/event/detail/components/EventDescription.tsx
+++ b/src/features/event/detail/components/EventDescription.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+interface DescriptionProps {
+  description?: string | null;
+}
+
+export default function EventDescription({ description }: DescriptionProps) {
+  return (
+    <section className="mb-14">
+      <h2 className="mb-2 text-lg font-semibold">이벤트 소개</h2>
+      {/* Glassmorphic Card */}
+      <div className="relative overflow-hidden rounded-3xl border border-white/30 bg-white/20 p-6 shadow-xl backdrop-blur-lg">
+        {/* Glossy Sheen */}
+        <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent" />
+        {/* 실제 본문 */}
+        <p className="relative text-sm leading-relaxed text-gray-800">{description}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/features/event/detail/components/EventInfoItem.tsx
+++ b/src/features/event/detail/components/EventInfoItem.tsx
@@ -3,14 +3,14 @@ import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 
-interface InfoItemProps {
+interface EventInfoItemProps {
   icon: ReactNode; // 왼쪽 아이콘 영역
   label: ReactNode; // 텍스트 또는 JSX
   href?: string; // 링크가 필요할 때
   external?: boolean; // 새 창 여부
 }
 
-export default function InfoItem({ icon, label, href, external = false }: InfoItemProps) {
+export default function EventInfoItem({ icon, label, href, external = false }: EventInfoItemProps) {
   const content = <span className="text-sm text-gray-500">{label}</span>;
 
   return (

--- a/src/features/event/detail/components/EventInfoList.tsx
+++ b/src/features/event/detail/components/EventInfoList.tsx
@@ -1,19 +1,19 @@
 'use client';
 import Chip from '@/components/common/chip';
-import InfoItem from '@/features/event/detail/components/InfoItem';
+import EventInfoItem from '@/features/event/detail/components/EventInfoItem';
 import { formatDate } from '@/utils/dateformatter';
 import { BanknotesIcon, InformationCircleIcon, MapPinIcon } from '@heroicons/react/24/outline';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
-interface InfoListProps {
+interface EventInfoListProps {
   eventStart: string | Date;
   eventEnd: string | Date;
   address?: string | null;
   extraInfo?: string[] | string | null;
 }
 
-export default function InfoList({ eventStart, eventEnd, address, extraInfo }: InfoListProps) {
+export default function EventInfoList({ eventStart, eventEnd, address, extraInfo }: EventInfoListProps) {
   // 날짜 파싱
   const start = new Date(eventStart);
   const month = format(start, 'M', { locale: ko });
@@ -36,7 +36,7 @@ export default function InfoList({ eventStart, eventEnd, address, extraInfo }: I
   return (
     <div className="space-y-2">
       {/* 일시 */}
-      <InfoItem
+      <EventInfoItem
         icon={
           <div className="flex h-8 w-8 flex-col overflow-hidden rounded border text-center shadow-sm">
             <div className="bg-gray-600/30 py-[2px] text-[8px] leading-none text-gray-500">{month}월</div>
@@ -47,7 +47,7 @@ export default function InfoList({ eventStart, eventEnd, address, extraInfo }: I
       />
 
       {/* 장소 */}
-      <InfoItem
+      <EventInfoItem
         icon={<MapPinIcon className="h-5 w-5 text-gray-500" />}
         label={place}
         href={`http://map.kakao.com/link/search/${place}`}
@@ -55,10 +55,10 @@ export default function InfoList({ eventStart, eventEnd, address, extraInfo }: I
       />
 
       {/* 비용 */}
-      <InfoItem icon={<BanknotesIcon className="h-5 w-5 text-gray-500" />} label="무료" />
+      <EventInfoItem icon={<BanknotesIcon className="h-5 w-5 text-gray-500" />} label="무료" />
 
       {/* 기타 안내 */}
-      <InfoItem
+      <EventInfoItem
         icon={<InformationCircleIcon className="h-5 w-5 text-gray-500" />}
         label={
           <>

--- a/src/features/event/detail/components/EventInfoList.tsx
+++ b/src/features/event/detail/components/EventInfoList.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Chip from '@/components/common/chip';
 import EventInfoItem from '@/features/event/detail/components/EventInfoItem';
+import { OTHER_INFO_MAP } from '@/features/event/register/services/otherInfoLabelHelper';
 import { getAddressPart } from '@/utils/adress';
 import { formatDate } from '@/utils/dateformatter';
 import { BanknotesIcon, InformationCircleIcon, MapPinIcon } from '@heroicons/react/24/outline';
@@ -63,9 +64,14 @@ export default function EventInfoList({ eventStart, eventEnd, address, extraInfo
         icon={<InformationCircleIcon className="h-5 w-5 text-gray-500" />}
         label={
           <>
-            {extraInfos.map((info, idx) => (
-              <Chip key={idx}>{info}</Chip>
-            ))}
+            {extraInfos.map((infoId, idx) => {
+              const label = OTHER_INFO_MAP[infoId] ?? infoId;
+              return (
+                <Chip key={idx} className="mr-2">
+                  {label}{' '}
+                </Chip>
+              );
+            })}
           </>
         }
       />

--- a/src/features/event/detail/components/EventInfoList.tsx
+++ b/src/features/event/detail/components/EventInfoList.tsx
@@ -34,7 +34,7 @@ export default function EventInfoList({ eventStart, eventEnd, address, extraInfo
         : [];
 
   return (
-    <div className="space-y-2">
+    <section className="space-y-2">
       {/* 일시 */}
       <EventInfoItem
         icon={
@@ -68,6 +68,6 @@ export default function EventInfoList({ eventStart, eventEnd, address, extraInfo
           </>
         }
       />
-    </div>
+    </section>
   );
 }

--- a/src/features/event/detail/components/EventInfoList.tsx
+++ b/src/features/event/detail/components/EventInfoList.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Chip from '@/components/common/chip';
 import EventInfoItem from '@/features/event/detail/components/EventInfoItem';
+import { getAddressPart } from '@/utils/adress';
 import { formatDate } from '@/utils/dateformatter';
 import { BanknotesIcon, InformationCircleIcon, MapPinIcon } from '@heroicons/react/24/outline';
 import { format } from 'date-fns';
@@ -20,7 +21,7 @@ export default function EventInfoList({ eventStart, eventEnd, address, extraInfo
   const day = format(start, 'd', { locale: ko });
 
   // 장소
-  const place = address?.split(',').map((s) => s.trim())[1];
+  const place = getAddressPart(address!, 1);
 
   // 기타 정보
   const extraInfos =

--- a/src/features/event/detail/components/EventMapPanel.tsx
+++ b/src/features/event/detail/components/EventMapPanel.tsx
@@ -1,40 +1,27 @@
 'use client';
 
 import Button from '@/components/common/button';
+import MapContainer from '@/features/event/detail/components/MapContainer';
 import ShareButton from '@/features/event/detail/components/ShareButton';
 import useGeocode from '@/features/event/detail/hooks/useGeocode';
 import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Avatar } from '@heroui/react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 interface KakaoMapProps {
   address?: string;
   organizer: string;
 }
-// 맵 로드
 export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
   const { eventId } = useParams();
   const safeAddress = address ?? '';
   const { position } = useGeocode(safeAddress);
 
   return (
-    <section className="h-130 w-80">
+    <main className="h-130 w-80">
       {/* 지도 */}
-      <div className="mb-6 w-full max-w-4xl transform overflow-hidden rounded-2xl shadow-2xl transition-transform hover:-translate-y-2">
-        <Map
-          id="map"
-          center={position!}
-          style={{
-            width: '100%',
-            height: '400px',
-          }}
-          level={3}
-        >
-          <MapMarker position={position!} />
-        </Map>
-      </div>
+      <MapContainer center={position!} />
       {/* 주최자 */}
       {/* NOTE: 우선은 host-center로 연결해놨는데 주최자가 운영하고 있는/종료/예정인 팝업을 보여주는 페이지가 더 필요하지 않을까 싶음 */}
       <div className="mt-4 flex flex-col gap-2">
@@ -54,6 +41,6 @@ export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
           <ShareButton />
         </div>
       </div>
-    </section>
+    </main>
   );
 }

--- a/src/features/event/detail/components/EventMapPanel.tsx
+++ b/src/features/event/detail/components/EventMapPanel.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 interface KakaoMapProps {
-  address: string;
+  address?: string;
   organizer: string;
 }
 // 맵 로드
@@ -19,11 +19,11 @@ export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
   const { eventId } = useParams();
   const { isLoaded } = useKakaoLoader();
   const [position, setPosition] = useState({ lat: 33.167, lng: 126.570667 });
-
+  const safeAddress = address ?? '';
   useEffect(() => {
     if (!window.kakao?.maps) return;
     const geocoder = new kakao.maps.services.Geocoder();
-    geocoder.addressSearch(address, (result, status) => {
+    geocoder.addressSearch(safeAddress, (result, status) => {
       if (status === window.kakao.maps.services.Status.OK) {
         setPosition({
           lat: parseFloat(result[0].y),

--- a/src/features/event/detail/components/EventMapPanel.tsx
+++ b/src/features/event/detail/components/EventMapPanel.tsx
@@ -2,12 +2,11 @@
 
 import Button from '@/components/common/button';
 import ShareButton from '@/features/event/detail/components/ShareButton';
-import useKakaoLoader from '@/hooks/useKakaoLoader';
+import useGeocode from '@/features/event/detail/hooks/useGeocode';
 import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 import { Avatar } from '@heroui/react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 interface KakaoMapProps {
@@ -17,21 +16,8 @@ interface KakaoMapProps {
 // 맵 로드
 export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
   const { eventId } = useParams();
-  const { isLoaded } = useKakaoLoader();
-  const [position, setPosition] = useState({ lat: 33.167, lng: 126.570667 });
   const safeAddress = address ?? '';
-  useEffect(() => {
-    if (!window.kakao?.maps) return;
-    const geocoder = new kakao.maps.services.Geocoder();
-    geocoder.addressSearch(safeAddress, (result, status) => {
-      if (status === window.kakao.maps.services.Status.OK) {
-        setPosition({
-          lat: parseFloat(result[0].y),
-          lng: parseFloat(result[0].x),
-        });
-      }
-    });
-  }, [isLoaded, address]);
+  const { position } = useGeocode(safeAddress);
 
   return (
     <section className="h-130 w-80">
@@ -39,14 +25,14 @@ export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
       <div className="mb-6 w-full max-w-4xl transform overflow-hidden rounded-2xl shadow-2xl transition-transform hover:-translate-y-2">
         <Map
           id="map"
-          center={position}
+          center={position!}
           style={{
             width: '100%',
             height: '400px',
           }}
           level={3}
         >
-          <MapMarker position={position} />
+          <MapMarker position={position!} />
         </Map>
       </div>
       {/* 주최자 */}

--- a/src/features/event/detail/components/EventMapPanel.tsx
+++ b/src/features/event/detail/components/EventMapPanel.tsx
@@ -1,19 +1,15 @@
 'use client';
 
-import Button from '@/components/common/button';
+import EventActionButtons from '@/features/event/detail/components/EventActionButtons';
 import MapContainer from '@/features/event/detail/components/MapContainer';
 import OrganizerInfo from '@/features/event/detail/components/OrganizerInfo';
-import ShareButton from '@/features/event/detail/components/ShareButton';
 import useGeocode from '@/features/event/detail/hooks/useGeocode';
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
 interface KakaoMapProps {
   address?: string;
   organizer: string;
 }
 export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
-  const { eventId } = useParams();
   const safeAddress = address ?? '';
   const { position } = useGeocode(safeAddress);
 
@@ -23,19 +19,10 @@ export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
       <MapContainer center={position!} />
       {/* 주최자 */}
       {/* NOTE: 우선은 host-center로 연결해놨는데 주최자가 운영하고 있는/종료/예정인 팝업을 보여주는 페이지가 더 필요하지 않을까 싶음 */}
-      <div className="mt-4 flex flex-col gap-2">
-        <OrganizerInfo organizer={organizer} />
-        {/* 신청 버튼*/}
-        <Link href={`/event/${eventId}/participate`}>
-          <Button fullWidth>신청하기</Button>
-        </Link>
-        {/* 관심 행사 등록*/}
-        {/* NOTE: 토스트로 '관심행사로 등록되었습니다 띄워주기' */}
-        <div className="flex flex-row items-center gap-6">
-          <Button fullWidth>관심 행사</Button>
-          <ShareButton />
-        </div>
-      </div>
+      <OrganizerInfo organizer={organizer} />
+      {/* 신청 버튼*/}
+      {/* TODO: 토스트 알림필요! */}
+      <EventActionButtons />
     </main>
   );
 }

--- a/src/features/event/detail/components/EventMapPanel.tsx
+++ b/src/features/event/detail/components/EventMapPanel.tsx
@@ -2,10 +2,9 @@
 
 import Button from '@/components/common/button';
 import MapContainer from '@/features/event/detail/components/MapContainer';
+import OrganizerInfo from '@/features/event/detail/components/OrganizerInfo';
 import ShareButton from '@/features/event/detail/components/ShareButton';
 import useGeocode from '@/features/event/detail/hooks/useGeocode';
-import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
-import { Avatar } from '@heroui/react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
@@ -25,11 +24,7 @@ export default function EventMapPanel({ address, organizer }: KakaoMapProps) {
       {/* 주최자 */}
       {/* NOTE: 우선은 host-center로 연결해놨는데 주최자가 운영하고 있는/종료/예정인 팝업을 보여주는 페이지가 더 필요하지 않을까 싶음 */}
       <div className="mt-4 flex flex-col gap-2">
-        <Link className="mb-2 flex flex-row items-center gap-2" href={`/host-center`}>
-          <Avatar src={undefined} showFallback as="button" className="h-7 w-7 cursor-pointer" color="danger" />
-          <h4 className="text-lg font-semibold text-gray-500">{organizer}</h4>
-          <ChevronDoubleRightIcon className="h-5 w-5 text-gray-500" />
-        </Link>
+        <OrganizerInfo organizer={organizer} />
         {/* 신청 버튼*/}
         <Link href={`/event/${eventId}/participate`}>
           <Button fullWidth>신청하기</Button>

--- a/src/features/event/detail/components/EventMobileBar.tsx
+++ b/src/features/event/detail/components/EventMobileBar.tsx
@@ -1,7 +1,6 @@
 import Button from '@/components/common/button';
 import ShareButton from '@/features/event/detail/components/ShareButton';
-import { useSaveStore } from '@/store/useSaveStore';
-import { saveStoreDebounce } from '@/utils/saveStoreDebounce';
+import useHandleSave from '@/hooks/useHandleSave';
 import { HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
 import { HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
 import { useSession } from 'next-auth/react';
@@ -15,15 +14,7 @@ interface EventMobileBarProps {
 export default function EventMobileBar({ priceLabel, eventId }: EventMobileBarProps) {
   const { data: session } = useSession();
   const userId = session?.user?.id;
-
-  const savedStores = useSaveStore((s) => s.savedStores);
-  const toggleSaveStore = useSaveStore((s) => s.toggleSaveStore);
-  const isSaved = savedStores.includes(eventId);
-
-  const handleSaves = () => {
-    toggleSaveStore(eventId);
-    saveStoreDebounce(eventId, !isSaved, userId);
-  };
+  const { isSaved, toggle } = useHandleSave(eventId, userId);
 
   return (
     <div className="fixed inset-x-4 bottom-4 z-50 flex items-center justify-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
@@ -35,7 +26,7 @@ export default function EventMobileBar({ priceLabel, eventId }: EventMobileBarPr
       {/* 버튼 그룹  */}
       <div className="flex items-center space-x-3">
         {/* 관심 팝업(하트) */}
-        <Button isIconOnly onPress={handleSaves}>
+        <Button isIconOnly onPress={toggle}>
           {isSaved ? (
             <HeartSolid className="h-5 w-5 text-red-500" />
           ) : (

--- a/src/features/event/detail/components/EventMobileBar.tsx
+++ b/src/features/event/detail/components/EventMobileBar.tsx
@@ -1,0 +1,40 @@
+import Button from '@/components/common/button';
+import ShareButton from '@/features/event/detail/components/ShareButton';
+import { HeartIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+
+interface EventMobileBarProps {
+  priceLabel: string;
+  onToggleSave?: () => void;
+  saved?: boolean;
+  eventId: string;
+}
+
+export default function EventMobileBar({ priceLabel, eventId }: EventMobileBarProps) {
+  return (
+    <div className="fixed inset-x-4 bottom-4 z-50 flex items-center justify-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
+      {/* 가격 정보 */}
+      <div className="flex-1 flex-shrink-0 flex-col items-center justify-center">
+        <p className="text-xs text-gray-500">티켓 가격</p>
+        <p className="text-lg font-semibold text-gray-800">{priceLabel}</p>
+      </div>
+      {/* 버튼 그룹  */}
+      <div className="flex items-center space-x-3">
+        {/* 관심 팝업(하트) */}
+        <Button isIconOnly>
+          <HeartIcon className="h-5 w-5 text-red-500" />
+        </Button>
+        {/* 링크 공유 */}
+        <ShareButton />
+        {/* 신청 버튼 */}
+        <Link href={`/event/${eventId}/participate`}>
+          <Button className="rounded-lg bg-gradient-to-r from-pink-400 to-blue-400 px-8 font-semibold text-white shadow-2xl backdrop-blur-2xl transition hover:scale-105 dark:text-white">
+            {/* 신청하기 버튼 Glowy 효과 */}
+            <div className="pointer-events-none absolute top-0 left-0 h-2 w-full animate-pulse bg-gradient-to-b from-white/50 to-transparent px-4" />
+            신청하기
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/event/detail/components/EventMobileBar.tsx
+++ b/src/features/event/detail/components/EventMobileBar.tsx
@@ -1,16 +1,30 @@
 import Button from '@/components/common/button';
 import ShareButton from '@/features/event/detail/components/ShareButton';
-import { HeartIcon } from '@heroicons/react/24/outline';
+import { useSaveStore } from '@/store/useSaveStore';
+import { saveStoreDebounce } from '@/utils/saveStoreDebounce';
+import { HeartIcon as HeartOutline } from '@heroicons/react/24/outline';
+import { HeartIcon as HeartSolid } from '@heroicons/react/24/solid';
+import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 
 interface EventMobileBarProps {
   priceLabel: string;
-  onToggleSave?: () => void;
-  saved?: boolean;
   eventId: string;
 }
 
 export default function EventMobileBar({ priceLabel, eventId }: EventMobileBarProps) {
+  const { data: session } = useSession();
+  const userId = session?.user?.id;
+
+  const savedStores = useSaveStore((s) => s.savedStores);
+  const toggleSaveStore = useSaveStore((s) => s.toggleSaveStore);
+  const isSaved = savedStores.includes(eventId);
+
+  const handleSaves = () => {
+    toggleSaveStore(eventId);
+    saveStoreDebounce(eventId, !isSaved, userId);
+  };
+
   return (
     <div className="fixed inset-x-4 bottom-4 z-50 flex items-center justify-center rounded-2xl bg-white/20 p-4 shadow-xl backdrop-blur-lg lg:hidden">
       {/* 가격 정보 */}
@@ -21,8 +35,12 @@ export default function EventMobileBar({ priceLabel, eventId }: EventMobileBarPr
       {/* 버튼 그룹  */}
       <div className="flex items-center space-x-3">
         {/* 관심 팝업(하트) */}
-        <Button isIconOnly>
-          <HeartIcon className="h-5 w-5 text-red-500" />
+        <Button isIconOnly onPress={handleSaves}>
+          {isSaved ? (
+            <HeartSolid className="h-5 w-5 text-red-500" />
+          ) : (
+            <HeartOutline className="h-5 w-5 text-red-500" />
+          )}
         </Button>
         {/* 링크 공유 */}
         <ShareButton />

--- a/src/features/event/detail/components/EventPoster.tsx
+++ b/src/features/event/detail/components/EventPoster.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Image } from '@heroui/image';
+import NextImage, { StaticImageData } from 'next/image';
+
+interface EventPosterProps {
+  src: string | StaticImageData | null;
+  alt: string;
+  width?: number;
+  height?: number;
+}
+
+export default function EventPoster({ src, alt, width = 400, height = 500 }: EventPosterProps) {
+  if (!src) return null;
+  const imageSrc = typeof src === 'string' ? src : src.src;
+
+  return (
+    <figure className="mb-6 flex justify-center">
+      <Image isBlurred as={NextImage} src={imageSrc} alt={alt} width={width} height={height} />
+    </figure>
+  );
+}

--- a/src/features/event/detail/components/EventTitle.tsx
+++ b/src/features/event/detail/components/EventTitle.tsx
@@ -9,13 +9,13 @@ interface EventTitleProps {
 
 export default function EventTitle({ title, hostName, hostLink }: EventTitleProps) {
   return (
-    <div className="flex items-baseline space-x-3">
+    <section className="flex items-baseline space-x-3">
       <strong className="text-3xl drop-shadow-lg">{title}</strong>
       {/* 1024px 미만 반응형: 주최자명 */}
       <Link href={hostLink} className="inline-flex items-center space-x-1 text-sm text-gray-500 lg:hidden">
         <span className="truncate font-medium">{hostName}</span>
         <ChevronDoubleRightIcon className="h-4 w-4" />
       </Link>
-    </div>
+    </section>
   );
 }

--- a/src/features/event/detail/components/EventTitle.tsx
+++ b/src/features/event/detail/components/EventTitle.tsx
@@ -1,0 +1,21 @@
+import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+
+interface EventTitleProps {
+  title: string;
+  hostName: string;
+  hostLink: string;
+}
+
+export default function EventTitle({ title, hostName, hostLink }: EventTitleProps) {
+  return (
+    <div className="flex items-baseline space-x-3">
+      <strong className="text-3xl drop-shadow-lg">{title}</strong>
+      {/* 1024px 미만 반응형: 주최자명 */}
+      <Link href={hostLink} className="inline-flex items-center space-x-1 text-sm text-gray-500 lg:hidden">
+        <span className="truncate font-medium">{hostName}</span>
+        <ChevronDoubleRightIcon className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+}

--- a/src/features/event/detail/components/InfoItem.tsx
+++ b/src/features/event/detail/components/InfoItem.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+interface InfoItemProps {
+  icon: ReactNode; // 왼쪽 아이콘 영역
+  label: ReactNode; // 텍스트 또는 JSX
+  href?: string; // 링크가 필요할 때
+  external?: boolean; // 새 창 여부
+}
+
+export default function InfoItem({ icon, label, href, external = false }: InfoItemProps) {
+  const content = <span className="text-sm text-gray-500">{label}</span>;
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex h-8 w-8 items-center justify-center rounded">{icon}</div>
+      {href ? (
+        <Link href={href} target={external ? '_blank' : undefined} className="inline-flex items-center gap-1">
+          {content}
+          {external && <ArrowTopRightOnSquareIcon className="h-5 w-5 lg:hidden" />}
+        </Link>
+      ) : (
+        content
+      )}
+    </div>
+  );
+}

--- a/src/features/event/detail/components/InfoList.tsx
+++ b/src/features/event/detail/components/InfoList.tsx
@@ -1,0 +1,73 @@
+'use client';
+import Chip from '@/components/common/chip';
+import InfoItem from '@/features/event/detail/components/InfoItem';
+import { formatDate } from '@/utils/dateformatter';
+import { BanknotesIcon, InformationCircleIcon, MapPinIcon } from '@heroicons/react/24/outline';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+interface InfoListProps {
+  eventStart: string | Date;
+  eventEnd: string | Date;
+  address?: string | null;
+  extraInfo?: string[] | string | null;
+}
+
+export default function InfoList({ eventStart, eventEnd, address, extraInfo }: InfoListProps) {
+  // 날짜 파싱
+  const start = new Date(eventStart);
+  const month = format(start, 'M', { locale: ko });
+  const day = format(start, 'd', { locale: ko });
+
+  // 장소
+  const place = address?.split(',').map((s) => s.trim())[1];
+
+  // 기타 정보
+  const extraInfos =
+    typeof extraInfo === 'string'
+      ? extraInfo
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : Array.isArray(extraInfo)
+        ? extraInfo
+        : [];
+
+  return (
+    <div className="space-y-2">
+      {/* 일시 */}
+      <InfoItem
+        icon={
+          <div className="flex h-8 w-8 flex-col overflow-hidden rounded border text-center shadow-sm">
+            <div className="bg-gray-600/30 py-[2px] text-[8px] leading-none text-gray-500">{month}월</div>
+            <div className="bg-transparent py-[1px] text-xs font-semibold">{day}</div>
+          </div>
+        }
+        label={`${formatDate(eventStart)} ~ ${formatDate(eventEnd)}`}
+      />
+
+      {/* 장소 */}
+      <InfoItem
+        icon={<MapPinIcon className="h-5 w-5 text-gray-500" />}
+        label={place}
+        href={`http://map.kakao.com/link/search/${place}`}
+        external
+      />
+
+      {/* 비용 */}
+      <InfoItem icon={<BanknotesIcon className="h-5 w-5 text-gray-500" />} label="무료" />
+
+      {/* 기타 안내 */}
+      <InfoItem
+        icon={<InformationCircleIcon className="h-5 w-5 text-gray-500" />}
+        label={
+          <>
+            {extraInfos.map((info, idx) => (
+              <Chip key={idx}>{info}</Chip>
+            ))}
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/src/features/event/detail/components/MapContainer.tsx
+++ b/src/features/event/detail/components/MapContainer.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { LatLng } from '@/features/event/detail/hooks/useGeocode';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+
+interface MapContainerProps {
+  center: LatLng;
+  level?: number;
+  width?: string;
+  height?: string;
+}
+
+export default function MapContainer({ center, level = 3, width = '100%', height = '400px' }: MapContainerProps) {
+  return (
+    <section className="mb-6 w-full max-w-4xl transform overflow-hidden rounded-2xl shadow-2xl transition-transform hover:-translate-y-2">
+      <Map id="map" center={center} level={level} style={{ width, height }}>
+        <MapMarker position={center} />
+      </Map>
+    </section>
+  );
+}

--- a/src/features/event/detail/components/OrganizerInfo.tsx
+++ b/src/features/event/detail/components/OrganizerInfo.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
+import { Avatar } from '@heroui/react';
+import Link from 'next/link';
+
+interface OrganizerInfoProps {
+  organizer: string;
+  avatarSrc?: string;
+  hostLink?: string;
+}
+
+export default function OrganizerInfo({ organizer, avatarSrc, hostLink = '/host-center' }: OrganizerInfoProps) {
+  return (
+    <Link href={hostLink} className="mb-2 flex items-center gap-2">
+      <Avatar src={avatarSrc} showFallback as="button" className="h-7 w-7 cursor-pointer" color="danger" />
+      <h4 className="text-lg font-semibold text-gray-500">{organizer}</h4>
+      <ChevronDoubleRightIcon className="h-5 w-5 text-gray-500" />
+    </Link>
+  );
+}

--- a/src/features/event/detail/components/OrganizerInfo.tsx
+++ b/src/features/event/detail/components/OrganizerInfo.tsx
@@ -12,7 +12,7 @@ interface OrganizerInfoProps {
 
 export default function OrganizerInfo({ organizer, avatarSrc, hostLink = '/host-center' }: OrganizerInfoProps) {
   return (
-    <Link href={hostLink} className="mb-2 flex items-center gap-2">
+    <Link href={hostLink} className="mt-4 mb-2 flex items-center gap-2">
       <Avatar src={avatarSrc} showFallback as="button" className="h-7 w-7 cursor-pointer" color="danger" />
       <h4 className="text-lg font-semibold text-gray-500">{organizer}</h4>
       <ChevronDoubleRightIcon className="h-5 w-5 text-gray-500" />

--- a/src/features/event/detail/components/ShareButton.tsx
+++ b/src/features/event/detail/components/ShareButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Button from '@/components/common/button';
-import { LinkIcon } from '@heroui/react';
+import { LinkIcon } from '@heroicons/react/24/outline';
 import { useParams } from 'next/navigation';
 import { useClipboard } from 'react-haiku';
 export default function ShareButton() {
@@ -10,12 +10,8 @@ export default function ShareButton() {
   return (
     <>
       {/* 1024px 미만: 아이콘만 */}
-      <Button
-        onPress={() => clipboard.copy(currentURL)}
-        isIconOnly
-        className="flex items-center justify-center rounded-lg border border-white/30 bg-white/30 shadow-2xl backdrop-blur-2xl transition hover:scale-105 lg:hidden dark:text-white"
-      >
-        <LinkIcon />
+      <Button onPress={() => clipboard.copy(currentURL)} isIconOnly>
+        <LinkIcon className="h-5 w-5" />
       </Button>
 
       {/* 1024px 이상: 기존 버튼 */}

--- a/src/features/event/detail/components/ShareButton.tsx
+++ b/src/features/event/detail/components/ShareButton.tsx
@@ -10,7 +10,11 @@ export default function ShareButton() {
   return (
     <>
       {/* 1024px 미만: 아이콘만 */}
-      <Button onPress={() => clipboard.copy(currentURL)} isIconOnly>
+      <Button
+        onPress={() => clipboard.copy(currentURL)}
+        isIconOnly
+        className="flex items-center justify-center rounded-lg border border-white/30 bg-white/30 shadow-2xl backdrop-blur-2xl transition hover:scale-105 lg:hidden dark:text-white"
+      >
         <LinkIcon className="h-5 w-5" />
       </Button>
 

--- a/src/features/event/detail/hooks/useGeocode.ts
+++ b/src/features/event/detail/hooks/useGeocode.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import useKakaoLoader from '@/hooks/useKakaoLoader';
+import { useEffect, useState } from 'react';
+
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export default function useGeocode(address: string) {
+  //HACK: 주소를 못 읽어오는 경우 띄워주는 기본좌표를 서울 중심으로 했는데 길찾기로 띄워줄까?
+  const [position, setPosition] = useState<LatLng | null>({ lat: 37.5642135, lng: 127.0016985 });
+  const { isLoaded } = useKakaoLoader();
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!window.kakao?.maps) {
+      setError(new Error('Kakao Map SDK not loaded'));
+      return;
+    }
+    if (!address) {
+      setError(new Error('No address provided'));
+      return;
+    }
+
+    const geocoder = new kakao.maps.services.Geocoder();
+    geocoder.addressSearch(address, (result, status) => {
+      if (status === window.kakao.maps.services.Status.OK) {
+        setPosition({
+          lat: parseFloat(result[0].y),
+          lng: parseFloat(result[0].x),
+        });
+      } else {
+        setError(new Error('Failed to geocode address'));
+      }
+    });
+  }, [isLoaded, address]);
+  return { position, isLoaded, error };
+}

--- a/src/features/event/detail/services/getEventById.ts
+++ b/src/features/event/detail/services/getEventById.ts
@@ -1,0 +1,11 @@
+import { clientApi } from '@/libs/api';
+import type { EventData } from '@/types/event';
+
+export async function getEventById(id: string): Promise<EventData | null> {
+  try {
+    const data = await clientApi<EventData>(`/api/events/${id}`, { method: 'GET' });
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/event/detail/services/getHostByEventId.ts
+++ b/src/features/event/detail/services/getHostByEventId.ts
@@ -1,0 +1,11 @@
+import { clientApi } from '@/libs/api';
+import type { User } from '@/types/user';
+
+export async function getHostByEventId(id: string): Promise<User | null> {
+  try {
+    const [host] = await clientApi<User[]>(`/api/users/${id}`, { method: 'GET' });
+    return host ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/features/event/detail/types/index.ts
+++ b/src/features/event/detail/types/index.ts
@@ -1,0 +1,3 @@
+export interface PageProps {
+  params: Promise<{ eventId: string }>;
+}

--- a/src/features/event/register/services/otherInfoLabelHelper.ts
+++ b/src/features/event/register/services/otherInfoLabelHelper.ts
@@ -10,3 +10,7 @@ export const OTHER_INFO_OPTIONS = [
   { id: 'wifi', label: '와이파이 가능' },
   { id: 'photography_allowed', label: '사진촬영 가능' },
 ];
+
+export const OTHER_INFO_MAP: Record<string, string> = Object.fromEntries(
+  OTHER_INFO_OPTIONS.map(({ id, label }) => [id, label])
+);

--- a/src/hooks/useHandleSave.ts
+++ b/src/hooks/useHandleSave.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useSaveStore } from '@/store/useSaveStore';
+import { saveStoreDebounce } from '@/utils/saveStoreDebounce';
+
+export default function useHandleSave(eventId: string, userId?: string) {
+  // Zustand에서 가져오기
+  const savedStores = useSaveStore((s) => s.savedStores);
+  const toggleSaveStore = useSaveStore((s) => s.toggleSaveStore);
+
+  // 현재 저장 여부
+  const isSaved = savedStores.includes(eventId);
+
+  // 토글 핸들러
+  const toggle = () => {
+    toggleSaveStore(eventId);
+    saveStoreDebounce(eventId, !isSaved, userId);
+  };
+
+  return { isSaved, toggle };
+}

--- a/src/utils/adress.ts
+++ b/src/utils/adress.ts
@@ -1,0 +1,23 @@
+/**
+ * 쉼표로 구분된 주소 문자열을 배열로 반환
+ */
+export function getAddressParts(address: string): string[] {
+  return address
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * 주소 배열을 인덱스로 꺼내줌
+ * @param address 전체 주소 문자열
+ * @param partIndex 꺼내고 싶은 파트 인덱스 (0부터 시작).
+ *                  out-of-range면 fallbackIndex, 그마저도 없으면 빈 문자열 반환
+ * @param fallbackIndex 기본값으로 사용할 파트 인덱스 (default: 0)
+ */
+export function getAddressPart(address: string, partIndex: number, fallbackIndex = 0): string {
+  const parts = getAddressParts(address);
+  if (parts[partIndex] != null) return parts[partIndex]!;
+  if (parts[fallbackIndex] != null) return parts[fallbackIndex]!;
+  return '';
+}


### PR DESCRIPTION
## ✨ 작업 개요
이벤트 상세 페이지 전면 리팩토링 : 데이터 호출 로직과 UI 컴포넌트를 분리, 맵·관심 토글·기타 안내 등 역할별 모듈화

## 📌 변경사항 요약
- **서비스 레이어 분리**  
  - `getEventById` / `getUserById` 함수로 API 호출 이관  
  - 주소 파싱 로직 추출해 유틸함수로 활용
- **페이지 컴포넌트 구조 변경**  
  - 서버 컴포넌트 `Page` → UI 컴포넌트 `EventDetailPage` 분리  
- **UI 컴포넌트 추출**  
  - `Poster`, `Title`, `InfoItem`/`InfoList`, `Description`  
- **맵 & 주최자·액션 바 리팩토링**  
  - `useGeocode` 훅 :  주소값 -> 좌표 변환 로직 분리  
  - `MapContainer` 컴포넌트 : 지도 뷰 모듈화  
  - `OrganizerInfo` / `EventActionButtons` / `EventMobileBar`로 버튼 그룹 분리  
- **관심 토글 로직 통합**  
  - `useEventSave` 훅으로 zustand 토글 + debounce API 호출 묶음  
- **기타 안내 칩(id → label)**  
  - `OTHER_INFO_MAP` 으로 ID → 한글 라벨 매핑 후 `Chip` 렌더링  

## 🔍 상세 설명
1. **서비스 레이어**  
   - `src/features/event/map/services.ts`에 API 호출 모듈화 (`null` 반환 일원화)  
   - `/utils/location.ts`의 `parsePlace(address, index)` 로 주소 파싱 로직 분리  

2. **UI 컴포넌트**  
   - **`Poster`**: `<figure>` 시맨틱 + Next/Image + blur 처리  
   - **`Title`**: 이벤트 타이틀 + 호스트 링크 (반응형 표시)  
   - **`InfoItem` / `InfoList`**: 아이콘+텍스트 반복 구조 추상화  
   - **`Description`**: 이벤트 소개 영역  

3. **맵 & 동적 로직**  
   - **`useGeocode`**: 카카오 SDK 로드, 주소 → 위·경도 변환, 로딩·에러 상태 관리  
   - **`MapContainer`**: `center` 좌표 기반 지도 렌더링  
   - **`OrganizerInfo`**: 호스트 아바타 & 링크  
   - **`EventActionButtons` / `EventMobileBar`**: 신청·관심·공유 버튼 UI + `useEventSave` 로직 연동  

4. **관심 토글 최적화**  
   - **`useEventSave`** 훅  
     ```ts
     const { isSaved, toggle } = useEventSave(eventId, userId);
     ```  
     상태 조회 및 debounce API 호출 토글을 한 번에 처리  

5. **기타 안내 칩 매핑**  
   - `utils/eventInfoOptions.ts` 에서  
     ```ts
     export const OTHER_INFO_MAP: Record<string,string>
     ```  
   - `EventInfoList` 에서 `extraInfo.map(id => OTHER_INFO_MAP[id] ?? id)` 으로 변환  

## 🧪 테스트
- **로컬 수동 확인**  
  - 이벤트 상세 진입 → 모든 컴포넌트 정상 렌더링  
  - 맵 로딩 및 주소에 따른 마커 위치 확인  
  - 호스트 링크, 신청 버튼, 공유 버튼 기능 점검  
  - 관심 토글 클릭 → 즉시 UI 반영 후 0.4s 뒤 API 호출 확인  
  - 새로고침 시 서버 저장 여부에 맞춰 초기 상태 깜빡임 없이 표시  
  - `extraInfo` 칩이 ID → 한글 라벨로 올바르게 렌더링  
- **단위 테스트 / 스토리북** (추가 가능)  
  - `InfoItem`, `MapContainer`, `useEventSave` 훅 등  

## 📝 참고사항
- 에러 바운더리/로딩 스켈레톤: Suspense 또는 Error Boundary 도입 검토  
- 스타일 통일: Tailwind `@apply` 활용해 공통 유틸 클래스 정의  
- 접근성: `<time>`, `aria-label`, `aria-pressed` 등 보완 필요  
