### PR TITLE
Feature/toast

### DIFF
--- a/src/features/add-info/components/AddInfoForm.tsx
+++ b/src/features/add-info/components/AddInfoForm.tsx
@@ -7,6 +7,7 @@ import { LABELS } from '@/components/common/input/labels';
 import Select from '@/components/common/select';
 import useGetUserInfo from '@/hooks/useGetUserInfo';
 import { useAddInfoFormStore } from '@/store/add-info/useAddInfoFormStore';
+import { addToast } from '@heroui/react';
 import { useEffect } from 'react';
 import { updateUserInfo } from '../api/updateUserInfo';
 import { validateName } from '../services/nameValidation';
@@ -59,19 +60,30 @@ export default function AddInfoForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const { name, email, phone, role, nameValid, emailValid, phoneValid } = useAddInfoFormStore.getState(); // NOTE: interest 어떻게
-    if (!name || !email || !phone || !role) {
-      alert('모든 필드를 입력해주세요.'); // TODO: Toast
-      return;
-    }
+    const requiredFields = [name, email, phone, role];
+    const validityFlags = [nameValid, emailValid, phoneValid];
 
-    if (!nameValid || !emailValid || !phoneValid) {
-      alert('모든 필드를 입력해주세요.'); // TODO: Toast
+    if (requiredFields.some((field) => !field) || validityFlags.some((flag) => !flag)) {
+      addToast({
+        title: '모든 필드를 입력해주세요.',
+        color: 'warning',
+      });
       return;
     }
 
     if (userId) {
-      updateUserInfo({ name, email, phone, role }, userId);
-      return;
+      try {
+        await updateUserInfo({ name, email, phone, role }, userId);
+        addToast({ title: '업데이트 완료', color: 'success' });
+        // 필요하면 폼 초기화나 페이지 이동 추가
+      } catch (error) {
+        console.error(error);
+        addToast({
+          title: '업데이트 실패',
+          description: '다시 시도해주세요.',
+          color: 'danger',
+        });
+      }
     }
   };
 

--- a/src/features/popup-participate/api/createParticipate.ts
+++ b/src/features/popup-participate/api/createParticipate.ts
@@ -1,4 +1,5 @@
 import { clientApi } from '@/libs/api';
+import { addToast } from '@heroui/react';
 
 interface ParticipateDTO {
   name: string;
@@ -23,10 +24,16 @@ export const createParticipate = async ({ name, email, phone, tickets }: Partici
     });
 
     if (res.ok) {
-      console.log('참가자 생성 결과:', res);
-      alert('참여 신청이 완료되었습니다!');
+      addToast({
+        title: '참여 신청이 완료되었습니다!',
+        color: 'success',
+      });
     }
   } catch (err) {
     console.error('신청 중 오류:', err);
+    addToast({
+      title: '참여 신청에 실패했습니다. 다시 시도해주세요.',
+      color: 'danger',
+    });
   }
 };

--- a/src/features/popup-participate/components/ParticipateForm.tsx
+++ b/src/features/popup-participate/components/ParticipateForm.tsx
@@ -11,6 +11,7 @@ import { createParticipate } from '@/features/popup-participate/api/createPartic
 import { validateTickets } from '@/features/popup-participate/services/validateTickets';
 import useGetUserInfo from '@/hooks/useGetUserInfo';
 import { useEventParticipateFormStore } from '@/store/event-participate/useEventParticipateFormStore';
+import { addToast } from '@heroui/react';
 import { useEffect } from 'react';
 
 const inputOptions = {
@@ -65,7 +66,10 @@ export default function ParticipateForm({ eventId }: ParticipateFormProps) {
     const { name, email, phone, tickets } = useEventParticipateFormStore.getState();
 
     if (!name || !email || !phone || !tickets) {
-      alert('모든 필드를 입력해주세요.'); // TODO: Toast
+      addToast({
+        title: '모든 필드를 입력해주세요.',
+        color: 'warning',
+      });
       return;
     }
     // const body: Pick<CreateEventParticipant, 'participantStatus' | 'tickets'> = {

--- a/src/features/profile/components/MembershipWithdrawal.tsx
+++ b/src/features/profile/components/MembershipWithdrawal.tsx
@@ -1,6 +1,15 @@
 import Button from '@/components/common/button';
 import type { User } from '@/types/user';
-import { Divider, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, useDisclosure } from '@heroui/react';
+import {
+  addToast,
+  Divider,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  useDisclosure,
+} from '@heroui/react';
 import { signOut } from 'next-auth/react';
 import { deleteUser } from '../api/deleteUser';
 
@@ -13,11 +22,16 @@ export default function MembershipWithdrawal({ userInfo }: MembershipWithdrawalP
   const handleDeleteUser = async () => {
     const { success } = await deleteUser(userInfo.id);
     if (success) {
-      // TODO: toast(토스트) 작업 필요
-      alert('회원 탈퇴가 완료되었습니다.');
+      addToast({
+        title: '회원 탈퇴가 완료되었습니다.',
+        color: 'success',
+      });
       await signOut({ callbackUrl: '/' });
     } else {
-      alert('탈퇴 중 오류가 발생했습니다. 다시 시도해주세요.');
+      addToast({
+        title: '탈퇴 중 오류가 발생했습니다. 다시 시도해주세요.',
+        color: 'danger',
+      });
     }
   };
 

--- a/src/providers/providers.tsx
+++ b/src/providers/providers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SignInModalProvider } from '@/features/sign-in/SignInModalContext';
-import { HeroUIProvider } from '@heroui/react';
+import { HeroUIProvider, ToastProvider } from '@heroui/react';
 import { SessionProvider } from 'next-auth/react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { AuthSyncProvider } from './AuthSyncProvider';
@@ -9,6 +9,7 @@ import { AuthSyncProvider } from './AuthSyncProvider';
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <HeroUIProvider>
+      <ToastProvider />
       <NextThemesProvider attribute="class" defaultTheme="dark">
         <SessionProvider>
           <AuthSyncProvider>


### PR DESCRIPTION
## ✨ 작업 개요

HeroUI Toast를 도입. 기존의 `alert` 대신 사용자에게 비동기식 토스트 알림으로 피드백 제공

## 📌 변경사항 요약+ 🔍 상세 설명

- `hero-ui` Toast 전역 설정  
- 최상위 컴포넌트를 `ToastProvider`로 래핑  
- API 호출 성공/실패 시 토스트 알림 호출 로직 추가  


## 참고사항
-  토스트 스타일(위치, 지속시간, 애니메이션) 커스터마이징 하면 좋을듯
